### PR TITLE
fix(web): keep zero init off upgrade header

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+`bilig` is a `pnpm` monorepo. `apps/web` is the Vite/React shell, `apps/local-server` hosts local workbook sessions, and `apps/sync-server` handles sync services. Shared libraries live in `packages/`. Unit tests are usually in `src/__tests__/`, browser E2E tests in `e2e/tests`, architecture notes in `docs/`, and automation in `scripts/`.
+
+## Build, Test, and Development Commands
+Use Node `24+`, Bun, and `pnpm@10.32.1`.
+
+- `pnpm dev:web`: run the web shell.
+- `pnpm dev:web-local`: run the web shell and local server together.
+- `pnpm dev:sync`: run the sync server.
+- `pnpm build`: build all packages.
+- `pnpm lint`, `pnpm format`, `pnpm typecheck`: lint, format, and type-check.
+- `pnpm test`, `pnpm coverage`, `pnpm test:browser`: unit, coverage, and Playwright E2E runs.
+- `pnpm run ci`: full preflight, including generated-file and browser checks.
+
+## Coding Style & Naming Conventions
+Write strict TypeScript with ESM imports and explicit `.js` suffixes where the codebase already uses them. `oxfmt` enforces 2-space indentation, double quotes, and semicolons. Use `PascalCase` for React components and follow nearby filename conventions elsewhere. Avoid `any`; lint also fails on floating promises.
+
+## AssemblyScript & WASM
+`packages/wasm-kernel` is the repo’s AssemblyScript/WebAssembly fast path. AssemblyScript is TypeScript-like, but it compiles ahead-of-time to a static WebAssembly binary and exposes WebAssembly-native types such as `i32` and `f64`, so do not treat `assembly/` code like general app TypeScript. Keep kernel code deterministic, numeric, and explicit about value shapes. In this repo, JS remains the semantic source of truth; AssemblyScript is used to accelerate closed, computation-heavy formula families only after JS parity and differential tests are green. Build the kernel with `pnpm wasm:build`.
+
+## Testing Guidelines
+Add colocated unit tests as `*.test.ts` or `*.test.tsx`; keep browser flows in `e2e/tests/*.pw.ts`. Coverage gates apply to `packages/core`, `packages/formula`, and `packages/renderer`: 90% lines, statements, and functions, 70% branches. For targeted work, use filters such as `pnpm --filter @bilig/web test`.
+
+## Infra & Cluster Operations
+Cluster infrastructure for `bilig` does not live in this repo. The GitOps source of truth is the sibling repo at `~/github.com/lab`, especially `argocd/applications/bilig`, with supporting infra automation under `ansible/`. Make infra changes there and let Argo CD reconcile; use direct cluster mutation only for debugging or emergencies.
+
+From `~/github.com/lab`, validate with `bun run lint:argocd`, `bun run tf:plan`, and `bun run ansible` as needed. Use `kubectl config current-context`, then inspect with `kubectl -n bilig get deploy,svc,pods`, `kubectl -n bilig logs -f deploy/bilig-web`, and `kubectl -n bilig rollout status deployment/bilig-sync`. For Argo CD, use `argocd context`, `argocd app get bilig`, `argocd app diff bilig`, and, when intentionally rolling out GitOps changes, `argocd app sync bilig && argocd app wait bilig --sync --health`.
+
+## Commit & Pull Request Guidelines
+Use Conventional Commits: `type(scope): summary`, for example `feat(grid): add fill-handle drag selection`. Keep commits focused and imperative. By default, you may commit and push directly to `main` once local CI is green, preferably via `pnpm run ci`. When a PR is used, include scope, risk, linked issues, commands run, and screenshots for `apps/web` UI changes. If you edit protocol or formula inventory sources, regenerate and commit the outputs, because CI fails on dirty tracked files.

--- a/apps/sync-server/src/server.ts
+++ b/apps/sync-server/src/server.ts
@@ -83,6 +83,7 @@ export function createSyncServer(options: SyncServerOptions = {}) {
     const session = resolveSessionIdentity(request, reply);
     const guest = session.userID.startsWith("guest:");
     return {
+      authToken: session.userID,
       userID: session.userID,
       userId: session.userID,
       roles: ["editor"],

--- a/apps/web/src/__tests__/session.test.ts
+++ b/apps/web/src/__tests__/session.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import { loadRuntimeSession, type BiligRuntimeSession } from "../session.js";
+
+const jsonResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+
+describe("loadRuntimeSession", () => {
+  test("uses the server-provided auth token when present", async () => {
+    const response = {
+      authToken: "token-123",
+      userID: "user-123",
+      roles: ["editor"],
+      isAuthenticated: true,
+      authSource: "header",
+    };
+    const fetchImpl = async () => jsonResponse(response);
+
+    const session = await loadRuntimeSession(fetchImpl);
+
+    expect(session).toEqual<BiligRuntimeSession>({
+      authToken: "token-123",
+      userId: "user-123",
+      roles: ["editor"],
+      isAuthenticated: true,
+      authSource: "header",
+    });
+  });
+
+  test("falls back to the resolved user id when auth token is missing", async () => {
+    const fetchImpl = async () =>
+      jsonResponse({
+        userId: "guest:abc",
+        authSource: "guest",
+      });
+
+    const session = await loadRuntimeSession(fetchImpl);
+
+    expect(session.authToken).toBe("guest:abc");
+    expect(session.userId).toBe("guest:abc");
+    expect(session.authSource).toBe("guest");
+  });
+});

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -16,6 +16,7 @@ void Promise.all([loadRuntimeConfig(), loadRuntimeSession()])
       <React.StrictMode>
         <ZeroProvider
           cacheURL={config.zeroCacheUrl}
+          auth={session.authToken}
           userID={session.userId}
           schema={schema}
           mutators={mutators}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,6 +4,7 @@ import { ZeroProvider } from "@rocicorp/zero/react";
 import { loadRuntimeConfig, mutators, schema } from "@bilig/zero-sync";
 import { App } from "./App";
 import { loadRuntimeSession } from "./session";
+import { ZERO_CONNECT_MAX_HEADER_LENGTH } from "./zero-connection";
 
 import "@glideapps/glide-data-grid/index.css";
 import "./index.css";
@@ -20,6 +21,7 @@ void Promise.all([loadRuntimeConfig(), loadRuntimeSession()])
           userID={session.userId}
           schema={schema}
           mutators={mutators}
+          maxHeaderLength={ZERO_CONNECT_MAX_HEADER_LENGTH}
         >
           <App config={config} />
         </ZeroProvider>

--- a/apps/web/src/session.ts
+++ b/apps/web/src/session.ts
@@ -1,4 +1,5 @@
 export interface BiligRuntimeSession {
+  authToken: string;
   userId: string;
   roles: string[];
   isAuthenticated: boolean;
@@ -21,6 +22,7 @@ export async function loadRuntimeSession(
 
   if (!response.ok) {
     return {
+      authToken: "guest:bootstrap-fallback",
       userId: "guest:bootstrap-fallback",
       roles: ["editor"],
       isAuthenticated: false,
@@ -32,12 +34,21 @@ export async function loadRuntimeSession(
   const payload = isRecord(rawPayload) ? rawPayload : {};
   const userId = payload["userId"];
   const userID = payload["userID"];
+  const authToken = payload["authToken"];
   const roles = payload["roles"];
   const isAuthenticated = payload["isAuthenticated"];
   const guest = payload["guest"];
   const authSource = payload["authSource"];
   const source = payload["source"];
   return {
+    authToken:
+      typeof authToken === "string" && authToken.length > 0
+        ? authToken
+        : typeof userId === "string" && userId.length > 0
+          ? userId
+          : typeof userID === "string" && userID.length > 0
+            ? userID
+            : "guest:bootstrap-fallback",
     userId:
       typeof userId === "string" && userId.length > 0
         ? userId

--- a/apps/web/src/zero-connection.ts
+++ b/apps/web/src/zero-connection.ts
@@ -1,0 +1,3 @@
+// Keep initConnection out of the websocket upgrade header. The live cluster
+// drops upgrades once the encoded Sec-WebSocket-Protocol gets too large.
+export const ZERO_CONNECT_MAX_HEADER_LENGTH = 1024;


### PR DESCRIPTION
## Summary\n- cap Zero websocket upgrade header size in the web bootstrap\n- force  to be sent after the socket opens instead of embedding the full payload in \n- preserve Zero auth token usage added in the earlier session fix\n\n## Verification\n- 
> @bilig/web@0.1.0 build /Users/gregkonush/github.com/bilig/apps/web
> tsc -p tsconfig.json && node ../../node_modules/vite/bin/vite.js build

vite v8.0.0 building client environment for production...
[2Ktransforming...✓ 2427 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                                     0.54 kB │ gzip:   0.30 kB
dist/assets/release-CG0UhICF.wasm                 271.10 kB │ gzip:  77.93 kB
dist/assets/workbook.worker-B672dzvs.js           486.28 kB
dist/assets/index-gcFTWA3y.css                     21.86 kB │ gzip:   5.39 kB
dist/assets/chunk-DECur_0Z.js                       0.68 kB │ gzip:   0.41 kB
dist/assets/data-grid-overlay-editor-CXPpVIw7.js    3.76 kB │ gzip:   1.84 kB
dist/assets/lazy-inspector-CjeaHZen.js              8.95 kB │ gzip:   3.52 kB
dist/assets/dist-CGAupd8D.js                       13.19 kB │ gzip:   5.60 kB
dist/assets/number-overlay-editor-CnBLPLnh.js      15.80 kB │ gzip:   6.00 kB
dist/assets/index-DZpfkeDR.js                     940.45 kB │ gzip: 287.55 kB

✓ built in 361ms\n- 
 RUN  v4.1.0 /Users/gregkonush/github.com/bilig


 Test Files  3 passed (3)
      Tests  9 passed (9)
   Start at  14:09:47
   Duration  1.14s (transform 881ms, setup 0ms, import 1.30s, tests 128ms, environment 207ms)\n- real production websocket probe against  returned  with auth-only header path\n- Playwright loaded the production workbook UI and the Zero client stayed on the new poke path without the old  failure