### PR TITLE
Add CSV-shaped input example for headless-workpaper

### DIFF
--- a/examples/headless-workpaper/README.md
+++ b/examples/headless-workpaper/README.md
@@ -170,7 +170,7 @@ Expected output:
 Run the CSV shaped input example when you want to see how to load a simple array or CSV-shaped data into a WorkPaper, add a formula-backed summary cell, and read back the result:
 
 ```sh
-npm run csv
+node csv-shaped-input.mjs
 ```
 
 Expected output:

--- a/examples/headless-workpaper/README.md
+++ b/examples/headless-workpaper/README.md
@@ -164,3 +164,20 @@ Expected output:
   "saveFileBytes": 1209
 }
 ```
+
+## CSV Shaped Input
+
+Run the CSV shaped input example when you want to see how to load a simple array or CSV-shaped data into a WorkPaper, add a formula-backed summary cell, and read back the result:
+
+```sh
+npm run csv
+```
+
+Expected output:
+
+```json
+{
+  "success": true,
+  "totalQ1": 480
+}
+```

--- a/examples/headless-workpaper/csv-shaped-input.mjs
+++ b/examples/headless-workpaper/csv-shaped-input.mjs
@@ -1,0 +1,48 @@
+import { WorkPaper } from '@bilig/headless'
+
+const csvInput = [
+  ['Product', 'Q1', 'Q2', 'Q3', 'Q4'],
+  ['Widget A', 100, 150, 200, 250],
+  ['Widget B', 80, 90, 100, 110],
+  ['Widget C', 300, 310, 320, 330],
+]
+
+const workbook = WorkPaper.buildFromSheets({
+  Data: csvInput,
+})
+
+const dataSheet = requireSheet(workbook, 'Data')
+
+// Add one formula-backed summary cell
+workbook.setCellContents({ sheet: dataSheet, row: 4, col: 0 }, 'Total Q1')
+workbook.setCellContents({ sheet: dataSheet, row: 4, col: 1 }, '=SUM(B2:B4)')
+
+// Read the display/result back
+const totalQ1Cell = workbook.getCellValue({ sheet: dataSheet, row: 4, col: 1 })
+
+const output = {
+  success: true,
+  totalQ1: totalQ1Cell.value,
+}
+
+assertSummary(output)
+console.log(JSON.stringify(output, null, 2))
+
+function requireSheet(workpaper, sheetName) {
+  const sheetId = workpaper.getSheetId(sheetName)
+  if (sheetId === undefined) {
+    throw new Error(`Expected sheet "${sheetName}" to exist`)
+  }
+  return sheetId
+}
+
+function assertSummary(summary) {
+  const expected = {
+    success: true,
+    totalQ1: 480,
+  }
+
+  if (JSON.stringify(summary) !== JSON.stringify(expected)) {
+    throw new Error(`Unexpected WorkPaper result: ${JSON.stringify(summary)}`)
+  }
+}

--- a/examples/headless-workpaper/package.json
+++ b/examples/headless-workpaper/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "scripts": {
     "agent:verify": "node agent-writeback-verification.mjs",
-    "csv": "node csv-shaped-input.mjs",
     "persistence": "node persistence-roundtrip.mjs",
     "scenarios": "node revenue-scenarios.mjs",
     "start": "node revenue-plan.mjs"

--- a/examples/headless-workpaper/package.json
+++ b/examples/headless-workpaper/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "agent:verify": "node agent-writeback-verification.mjs",
+    "csv": "node csv-shaped-input.mjs",
     "persistence": "node persistence-roundtrip.mjs",
     "scenarios": "node revenue-scenarios.mjs",
     "start": "node revenue-plan.mjs"


### PR DESCRIPTION
## Description
Added a minimal runnable example demonstrating CSV-shaped WorkPaper input using the public @bilig/headless API.

## Changes
- Added csv-shaped-input.mjs
- Demonstrates loading CSV-shaped input into a WorkPaper
- Adds a formula-backed summary cell
- Prints compact success output
- Updated README with new command
- Added npm script for convenience

Fixes #135