### PR TITLE
docs(examples): add named expression WorkPaper example

### DIFF
--- a/examples/headless-workpaper/README.md
+++ b/examples/headless-workpaper/README.md
@@ -219,6 +219,47 @@ Expected output:
 }
 ```
 
+## Named Expression Update
+
+Run the named expression example when you want to see a service or agent change
+a workbook-scoped named expression, recalculate dependent formulas, persist the
+workbook, restore it, and verify the restored value still matches the edited
+state:
+
+```sh
+npm run named-expression
+```
+
+Expected output:
+
+```json
+{
+  "verified": true,
+  "namedExpression": "GrowthRatePercent",
+  "before": {
+    "baseRevenue": 36000,
+    "growthAdjustedRevenue": 39600
+  },
+  "after": {
+    "baseRevenue": 36000,
+    "growthAdjustedRevenue": 45000
+  },
+  "restored": {
+    "baseRevenue": 36000,
+    "growthAdjustedRevenue": 45000
+  },
+  "namedExpressionValues": {
+    "before": 10,
+    "after": 25,
+    "restored": 25
+  },
+  "persistedNamedExpressions": [
+    "GrowthRatePercent"
+  ],
+  "restoredMatchesAfter": true
+}
+```
+
 ## CSV Shaped Input
 
 Run the CSV shaped input example when you want to see how to load a simple array or CSV-shaped data into a WorkPaper, add a formula-backed summary cell, and read back the result:

--- a/examples/headless-workpaper/named-expression-update.mjs
+++ b/examples/headless-workpaper/named-expression-update.mjs
@@ -1,0 +1,120 @@
+import {
+  WorkPaper,
+  createWorkPaperFromDocument,
+  exportWorkPaperDocument,
+  parseWorkPaperDocument,
+  serializeWorkPaperDocument,
+} from '@bilig/headless'
+
+const workbook = WorkPaper.buildFromSheets({
+  Pipeline: [
+    ['Stage', 'Revenue'],
+    ['Committed', 24000],
+    ['Expansion', 12000],
+  ],
+  Summary: [
+    ['Metric', 'Value'],
+    ['Base revenue', '=SUM(Pipeline!B2:B3)'],
+    ['Growth-adjusted revenue', null],
+  ],
+})
+
+const summarySheet = requireSheet(workbook, 'Summary')
+workbook.addNamedExpression('GrowthRatePercent', 10)
+workbook.setCellContents({ sheet: summarySheet, row: 2, col: 1 }, '=B2*(100+GrowthRatePercent)/100')
+
+const before = readSummary(workbook, summarySheet)
+const beforeNamedExpression = readNamedNumber(workbook, 'GrowthRatePercent')
+
+workbook.changeNamedExpression('GrowthRatePercent', 25)
+
+const after = readSummary(workbook, summarySheet)
+const afterNamedExpression = readNamedNumber(workbook, 'GrowthRatePercent')
+const serialized = serializeWorkPaperDocument(exportWorkPaperDocument(workbook, { includeConfig: true }))
+const restored = createWorkPaperFromDocument(parseWorkPaperDocument(serialized))
+const restoredSummarySheet = requireSheet(restored, 'Summary')
+const restoredSummary = readSummary(restored, restoredSummarySheet)
+const restoredNamedExpression = readNamedNumber(restored, 'GrowthRatePercent')
+
+const output = {
+  verified: true,
+  namedExpression: 'GrowthRatePercent',
+  before,
+  after,
+  restored: restoredSummary,
+  namedExpressionValues: {
+    before: beforeNamedExpression,
+    after: afterNamedExpression,
+    restored: restoredNamedExpression,
+  },
+  persistedNamedExpressions: restored.listNamedExpressions(),
+  restoredMatchesAfter: sameJson(restoredSummary, after) && restoredNamedExpression === afterNamedExpression,
+}
+
+assertOutput(output)
+console.log(JSON.stringify(output, null, 2))
+
+function requireSheet(workpaper, sheetName) {
+  const sheetId = workpaper.getSheetId(sheetName)
+  if (sheetId === undefined) {
+    throw new Error(`Expected sheet "${sheetName}" to exist`)
+  }
+  return sheetId
+}
+
+function readSummary(workpaper, summarySheet) {
+  return {
+    baseRevenue: readNumber(workpaper, summarySheet, 1, 1, 'base revenue'),
+    growthAdjustedRevenue: readNumber(workpaper, summarySheet, 2, 1, 'growth-adjusted revenue'),
+  }
+}
+
+function readNumber(workpaper, sheet, row, col, label) {
+  const cell = workpaper.getCellValue({ sheet, row, col })
+  if (!cell || typeof cell !== 'object' || !('value' in cell) || typeof cell.value !== 'number') {
+    throw new Error(`Expected ${label} to be a number, received ${JSON.stringify(cell)}`)
+  }
+  return cell.value
+}
+
+function readNamedNumber(workpaper, name) {
+  const cell = workpaper.getNamedExpressionValue(name)
+  if (!cell || typeof cell !== 'object' || !('value' in cell) || typeof cell.value !== 'number') {
+    throw new Error(`Expected named expression "${name}" to be a number, received ${JSON.stringify(cell)}`)
+  }
+  return cell.value
+}
+
+function sameJson(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right)
+}
+
+function assertOutput(actual) {
+  const expected = {
+    verified: true,
+    namedExpression: 'GrowthRatePercent',
+    before: {
+      baseRevenue: 36000,
+      growthAdjustedRevenue: 39600,
+    },
+    after: {
+      baseRevenue: 36000,
+      growthAdjustedRevenue: 45000,
+    },
+    restored: {
+      baseRevenue: 36000,
+      growthAdjustedRevenue: 45000,
+    },
+    namedExpressionValues: {
+      before: 10,
+      after: 25,
+      restored: 25,
+    },
+    persistedNamedExpressions: ['GrowthRatePercent'],
+    restoredMatchesAfter: true,
+  }
+
+  if (!sameJson(actual, expected)) {
+    throw new Error(`Unexpected named expression update result: ${JSON.stringify(actual)}`)
+  }
+}

--- a/examples/headless-workpaper/package.json
+++ b/examples/headless-workpaper/package.json
@@ -7,6 +7,7 @@
     "agent:tool-call": "node agent-tool-call-loop.mjs",
     "agent:verify": "node agent-writeback-verification.mjs",
     "json-records": "node json-records-input.mjs",
+    "named-expression": "node named-expression-update.mjs",
     "persistence": "node persistence-roundtrip.mjs",
     "scenarios": "node revenue-scenarios.mjs",
     "start": "node revenue-plan.mjs"


### PR DESCRIPTION
Adds a runnable `@bilig/headless` WorkPaper example for changing a workbook-scoped named expression.

The example:

- creates `GrowthRatePercent`;
- uses `changeNamedExpression` to update it;
- verifies a dependent formula recalculates;
- serializes and restores the workbook;
- proves the restored formula output and named expression value still match the edited state.

It also adds an `npm run named-expression` script and documents the command plus expected JSON output in the example README.

Fixes #138.

Verification:

```text
cd examples/headless-workpaper
npm install
npm run named-expression
npm start
npm run agent:verify
npm run persistence
npm run scenarios
cd ../..
node --check examples/headless-workpaper/named-expression-update.mjs
node -e "JSON.parse(require('fs').readFileSync('examples/headless-workpaper/package.json','utf8')); console.log('package json ok')"
git diff --check
```

Notes:

- `npm install` completed with local Node `v22.14.0` engine warnings because `@bilig/*` packages request Node `>=24.0.0`.
- `pnpm docs:discovery:check` could not be completed on this workstation before root dependencies were available; a root `pnpm install --frozen-lockfile` attempt timed out after 5 minutes.
