### PR TITLE
docs(examples): add JSON records WorkPaper example

### DIFF
--- a/examples/headless-workpaper/README.md
+++ b/examples/headless-workpaper/README.md
@@ -181,3 +181,25 @@ Expected output:
   "totalQ1": 480
 }
 ```
+
+## JSON Records Input
+
+Run the JSON records example when you want to see how to map service or API
+payload records into the row-array shape expected by
+`WorkPaper.buildFromSheets()`, add formula-backed summary cells, and validate
+the computed output:
+
+```sh
+npm run json-records
+```
+
+Expected output:
+
+```json
+{
+  "sourceRecords": 3,
+  "totalPipeline": 58200,
+  "westOpportunities": 20,
+  "verified": true
+}
+```

--- a/examples/headless-workpaper/json-records-input.mjs
+++ b/examples/headless-workpaper/json-records-input.mjs
@@ -1,0 +1,69 @@
+import { WorkPaper } from '@bilig/headless'
+
+const records = [
+  { channel: 'Partner', region: 'West', opportunities: 12, averageDealSize: 1800 },
+  { channel: 'Inbound', region: 'East', opportunities: 20, averageDealSize: 950 },
+  { channel: 'Outbound', region: 'West', opportunities: 8, averageDealSize: 2200 },
+]
+
+const rows = [
+  ['Channel', 'Region', 'Opportunities', 'Average Deal Size', 'Pipeline Value'],
+  ...records.map((record) => [
+    record.channel,
+    record.region,
+    record.opportunities,
+    record.averageDealSize,
+    '=C{row}*D{row}',
+  ]),
+].map((row, rowIndex) =>
+  row.map((cell) => (typeof cell === 'string' ? cell.replaceAll('{row}', String(rowIndex + 1)) : cell)),
+)
+
+const workbook = WorkPaper.buildFromSheets({
+  Pipeline: rows,
+  Summary: [
+    ['Metric', 'Value'],
+    ['Total pipeline', '=SUM(Pipeline!E2:E4)'],
+    ['West opportunities', '=SUMIF(Pipeline!B2:B4,"West",Pipeline!C2:C4)'],
+  ],
+})
+
+const summarySheet = requireSheet(workbook, 'Summary')
+const output = {
+  sourceRecords: records.length,
+  totalPipeline: readNumber(workbook, summarySheet, 1, 1, 'total pipeline'),
+  westOpportunities: readNumber(workbook, summarySheet, 2, 1, 'West opportunities'),
+  verified: true,
+}
+
+assertOutput(output)
+console.log(JSON.stringify(output, null, 2))
+
+function requireSheet(workpaper, sheetName) {
+  const sheetId = workpaper.getSheetId(sheetName)
+  if (sheetId === undefined) {
+    throw new Error(`Expected sheet "${sheetName}" to exist`)
+  }
+  return sheetId
+}
+
+function readNumber(workpaper, sheet, row, col, label) {
+  const cell = workpaper.getCellValue({ sheet, row, col })
+  if (!cell || typeof cell !== 'object' || !('value' in cell) || typeof cell.value !== 'number') {
+    throw new Error(`Expected ${label} to be a number, received ${JSON.stringify(cell)}`)
+  }
+  return cell.value
+}
+
+function assertOutput(actual) {
+  const expected = {
+    sourceRecords: 3,
+    totalPipeline: 58200,
+    westOpportunities: 20,
+    verified: true,
+  }
+
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`Unexpected JSON records input result: ${JSON.stringify(actual)}`)
+  }
+}

--- a/examples/headless-workpaper/package.json
+++ b/examples/headless-workpaper/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "agent:verify": "node agent-writeback-verification.mjs",
+    "json-records": "node json-records-input.mjs",
     "persistence": "node persistence-roundtrip.mjs",
     "scenarios": "node revenue-scenarios.mjs",
     "start": "node revenue-plan.mjs"


### PR DESCRIPTION
## Summary

Adds a runnable `@bilig/headless` example that converts plain JSON records into the row-array sheet shape consumed by `WorkPaper.buildFromSheets()`.

The example demonstrates:

- mapping JSON records into WorkPaper rows;
- adding a formula-backed summary sheet;
- reading computed values with `getCellValue()`;
- validating the exact expected JSON output.

## Changed files

- `examples/headless-workpaper/json-records-input.mjs`
- `examples/headless-workpaper/package.json`
- `examples/headless-workpaper/README.md`

## Verification

```text
npm run json-records
node --check examples/headless-workpaper/json-records-input.mjs
node -e "JSON.parse(require('fs').readFileSync('examples/headless-workpaper/package.json','utf8')); console.log('package json ok')"
git diff --cached --check
```

`npm run json-records` output:

```json
{
  "sourceRecords": 3,
  "totalPipeline": 58200,
  "westOpportunities": 20,
  "verified": true
}
```

Closes #137.
