### PR TITLE
docs(serverless): add SvelteKit endpoint adapter

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -190,6 +190,8 @@ including its p95 caveat.
   https://github.com/proompteng/bilig/issues/170
 - current small docs issue: AWS Lambda function URL adapter:
   https://github.com/proompteng/bilig/issues/171
+- current small docs issue: SvelteKit endpoint adapter:
+  https://github.com/proompteng/bilig/issues/173
 - good first issue search:
   https://github.com/proompteng/bilig/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22
 - first-timers-only issue search:

--- a/docs/serverless-workpaper-api-route.md
+++ b/docs/serverless-workpaper-api-route.md
@@ -430,6 +430,53 @@ curl -s -X POST http://localhost:3000/api/workpaper/revenue \
 If the Hono app is deployed to a worker or serverless runtime, pair this adapter
 with the durable storage variant above instead of relying on module memory.
 
+## SvelteKit Adapter
+
+SvelteKit route handlers already receive a web-standard `Request`, so the
+adapter should stay as small as the Hono and Next.js variants. Keep the
+WorkPaper logic in a shared module such as `src/lib/server/workpaper-route.js`,
+then call it from the route files.
+
+Create `src/routes/api/workpaper/summary/+server.js`:
+
+```js
+import { handleWorkPaperRequest } from '$lib/server/workpaper-route.js'
+
+export async function GET({ request }) {
+  return handleWorkPaperRequest(request)
+}
+```
+
+Create `src/routes/api/workpaper/revenue/+server.js`:
+
+```js
+import { handleWorkPaperRequest } from '$lib/server/workpaper-route.js'
+
+export async function POST({ request }) {
+  return handleWorkPaperRequest(request)
+}
+```
+
+The shared module should keep the `@bilig/headless` imports, `state`,
+`handleWorkPaperRequest()`, and the workbook helpers from the standalone route
+recipe. Omit the local `createServer()` adapter and the `toWebRequest()`
+translation helper because SvelteKit already hands your route a Fetch
+`Request`.
+
+The route path stays the same:
+
+```sh
+curl -s http://localhost:5173/api/workpaper/summary
+curl -s -X POST http://localhost:5173/api/workpaper/revenue \
+  -H 'content-type: application/json' \
+  -d '{"records":[{"region":"West","customers":20,"arpa":1200},{"region":"East","customers":30,"arpa":250},{"region":"Central","customers":18,"arpa":300},{"region":"North","customers":65,"arpa":180}]}'
+```
+
+Keep the framework files thin. The workbook route should still load the
+serialized WorkPaper document, apply the accepted edit, recalculate formulas,
+persist the next JSON document, and return summary proof through the shared
+handler instead of duplicating those details in each SvelteKit endpoint.
+
 ## Validation
 
 For the standalone recipe:


### PR DESCRIPTION
## What changed

- added a SvelteKit adapter section to `docs/serverless-workpaper-api-route.md`
- showed copyable `GET /api/workpaper/summary` and `POST /api/workpaper/revenue` handlers using SvelteKit `+server.js`
- kept the framework-specific code thin and pointed readers back to the shared `handleWorkPaperRequest(request)` boundary
- updated `docs/llms.txt` to include issue `#173`

## Why

This keeps the serverless WorkPaper route recipe aligned with the existing framework adapter sections and gives SvelteKit teams a direct copy path without changing workbook logic or adding runtime dependencies.

## Validation

- `pnpm docs:discovery:check`

## Notes

- no new dependencies were added
- the shared WorkPaper handler remains the source of truth for workbook logic and persistence behavior

Closes #173
