### PR TITLE
test(ci): cover deterministic release gzip measurement

### DIFF
--- a/scripts/__tests__/release-check-helpers.test.ts
+++ b/scripts/__tests__/release-check-helpers.test.ts
@@ -1,0 +1,17 @@
+import { gzipSync } from 'node:zlib'
+import { describe, expect, it, vi } from 'vitest'
+
+import { measureGzipBytes, releaseCheckGzipOptions } from '../release-check-helpers.ts'
+
+describe('release check gzip measurement', () => {
+  it('uses explicit deterministic gzip compression options', () => {
+    const bytes = new TextEncoder().encode('release-check bundle payload')
+    const gzip = vi.fn((input: Uint8Array, options: typeof releaseCheckGzipOptions) => gzipSync(input, options))
+
+    const measuredBytes = measureGzipBytes(bytes, gzip)
+
+    expect(gzip).toHaveBeenCalledExactlyOnceWith(bytes, releaseCheckGzipOptions)
+    expect(releaseCheckGzipOptions).toEqual({ level: 9 })
+    expect(measuredBytes).toBe(gzipSync(bytes, releaseCheckGzipOptions).byteLength)
+  })
+})

--- a/scripts/release-check-helpers.ts
+++ b/scripts/release-check-helpers.ts
@@ -1,0 +1,9 @@
+import { gzipSync } from 'node:zlib'
+
+export const releaseCheckGzipOptions = { level: 9 } as const
+
+type GzipSync = typeof gzipSync
+
+export function measureGzipBytes(bytes: Uint8Array, gzip: GzipSync = gzipSync): number {
+  return gzip(bytes, releaseCheckGzipOptions).byteLength
+}

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -1,10 +1,8 @@
 #!/usr/bin/env bun
 
-import { gzipSync } from 'node:zlib'
+import { measureGzipBytes } from './release-check-helpers.ts'
 import { readdir, readFile } from 'node:fs/promises'
 import { basename, resolve } from 'node:path'
-
-const gzipOptions = { level: 9 } as const
 
 const budgets = {
   mainJsGzipBytes: 350 * 1024,
@@ -53,7 +51,7 @@ async function measureAsset(file) {
   return {
     file,
     rawBytes: bytes.byteLength,
-    gzipBytes: gzipSync(bytes, gzipOptions).byteLength,
+    gzipBytes: measureGzipBytes(bytes),
   }
 }
 
@@ -144,7 +142,7 @@ const indexHtmlBytes = new Uint8Array(await readFile(indexHtml))
 const indexHtmlMeasurement = {
   file: indexHtml,
   rawBytes: indexHtmlBytes.byteLength,
-  gzipBytes: gzipSync(indexHtmlBytes, gzipOptions).byteLength,
+  gzipBytes: measureGzipBytes(indexHtmlBytes),
 }
 const startupRefs = parseStartupAssetReferences(await Bun.file(indexHtml).text())
 const startupCssFiles = [...new Set(startupRefs.stylesheetRefs)]


### PR DESCRIPTION
## Summary
- extract release-check gzip sizing into a small helper while preserving the existing JSON output shape
- keep gzip measurement pinned to explicit `{ level: 9 }` options
- add a focused regression test proving release-check gzip measurement calls zlib with those options

Closes #224.

## Verification
- `PATH=<bun-dlx-bin>:$PATH corepack pnpm exec vitest run scripts/__tests__/release-check-helpers.test.ts`
- `corepack pnpm exec oxlint --config .oxlintrc.json --type-aware --deny-warnings scripts/release-check.ts scripts/release-check-helpers.ts scripts/__tests__/release-check-helpers.test.ts`
- `PATH=<bun-dlx-bin>:$PATH corepack pnpm --filter @bilig/web build:bundle`
- `PATH=<bun-dlx-bin>:$PATH corepack pnpm release:check`

Note: full pre-push lint currently fails on unrelated existing `no-redundant-type-constituents` diagnostics in app/package test files under this local Node 22 setup; the touched release-check files pass targeted lint.
