### PR TITLE
docs(mcp): add stdio troubleshooting table

### DIFF
--- a/docs/mcp-workpaper-tool-server.md
+++ b/docs/mcp-workpaper-tool-server.md
@@ -47,6 +47,15 @@ The script implements two JSON-RPC methods shaped around the MCP tool model:
 - `tools/call` invokes the requested WorkPaper tool and returns text content
   plus structured formula readback.
 
+### MCP Stdio Troubleshooting
+
+| Symptom | What to check |
+| --- | --- |
+| `Parse error` response | Make sure each stdin line is valid JSON before it reaches the server. |
+| No response appears | End each JSON-RPC message with a newline; the server waits for newline-delimited input. |
+| Notification has no output | `notifications/initialized` is intentionally one-way and does not produce a JSON-RPC response. |
+| `Invalid params` or tool error | Check that `tools/call` includes a supported `name` and the required `arguments` for that tool. |
+
 The example deliberately avoids an MCP SDK dependency so the workbook contract
 is visible. Put the same handlers behind stdio, HTTP, or your MCP SDK adapter
 when you wire it into a production agent host.

--- a/examples/headless-workpaper/README.md
+++ b/examples/headless-workpaper/README.md
@@ -243,6 +243,15 @@ JSON-RPC response per line to stdout. It supports `initialize`,
 `notifications/initialized`, `tools/list`, and `tools/call` without adding a
 transport package or MCP SDK dependency.
 
+### MCP Stdio Troubleshooting
+
+| Symptom | What to check |
+| --- | --- |
+| `Parse error` response | Make sure each stdin line is valid JSON before it reaches the server. |
+| No response appears | End each JSON-RPC message with a newline; the server waits for newline-delimited input. |
+| Notification has no output | `notifications/initialized` is intentionally one-way and does not produce a JSON-RPC response. |
+| `Invalid params` or tool error | Check that `tools/call` includes a supported `name` and the required `arguments` for that tool. |
+
 ## Agent Writeback Verification
 
 Run the agent verification demo when you want a small artifact for the claim


### PR DESCRIPTION
## Summary
- Add a concise MCP stdio troubleshooting table to the headless WorkPaper example README
- Add the same table to the MCP WorkPaper tool server guide near the stdio command
- Cover invalid JSON, missing newlines, notifications with no response, and tool-call validation errors

Closes #232

## Testing
- `git diff --check`
- `pnpm docs:discovery:check`

Note: `git push` pre-push lint currently fails on existing type-aware lint errors outside this docs change.