### PR TITLE
docs(examples): add Vercel AI SDK MCP client recipe

### DIFF
--- a/docs/mcp-workpaper-tool-server.md
+++ b/docs/mcp-workpaper-tool-server.md
@@ -50,6 +50,52 @@ The package carries `mcpName: io.github.proompteng/bilig-workpaper` and a
 matching `server.json`, which is the metadata shape expected by MCP registries
 for npm-hosted stdio servers.
 
+## Vercel AI SDK MCP Client Recipe
+
+If your agent loop already uses the Vercel AI SDK, keep the MCP client thin and
+let the WorkPaper server own the spreadsheet reads and writes:
+
+```js
+import { createMCPClient } from '@ai-sdk/mcp'
+import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio'
+import { generateText } from 'ai'
+
+const client = await createMCPClient({
+  transport: new Experimental_StdioMCPTransport({
+    command: 'npm exec --package @bilig/headless -- bilig-workpaper-mcp',
+  }),
+})
+
+try {
+  const tools = await client.tools()
+  const { text } = await generateText({
+    model: 'your-model',
+    tools,
+    prompt: [
+      'Read the WorkPaper summary with read_workpaper_summary for Summary!A1:B5.',
+      'Then set Inputs!B3 to 0.4 with set_workpaper_input_cell.',
+      'Return editedCell plus the before and after expectedArr values.',
+    ].join('\n'),
+  })
+
+  console.log(text)
+} finally {
+  await client.close()
+}
+```
+
+The server command is `bilig-workpaper-mcp`; the `npm exec --package
+@bilig/headless -- bilig-workpaper-mcp` wrapper only resolves the published npm
+package for a clean checkout. The two tool calls prove the useful workflow: read
+a formula-backed summary, set one input cell, and return computed before/after
+readback.
+
+Verify the docs links and discovery metadata after editing this page:
+
+```sh
+pnpm docs:discovery:check
+```
+
 The script implements two JSON-RPC methods shaped around the MCP tool model:
 
 - `tools/list` returns `read_workpaper_summary` and

--- a/examples/headless-workpaper/README.md
+++ b/examples/headless-workpaper/README.md
@@ -243,6 +243,51 @@ JSON-RPC response per line to stdout. It supports `initialize`,
 `notifications/initialized`, `tools/list`, and `tools/call` without adding a
 transport package or MCP SDK dependency.
 
+### Vercel AI SDK MCP Client Recipe
+
+Use the published stdio command when you want an AI SDK agent to call the same
+MCP tools from a Node workflow:
+
+```js
+import { createMCPClient } from '@ai-sdk/mcp'
+import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio'
+import { generateText } from 'ai'
+
+const client = await createMCPClient({
+  transport: new Experimental_StdioMCPTransport({
+    command: 'npm exec --package @bilig/headless -- bilig-workpaper-mcp',
+  }),
+})
+
+try {
+  const tools = await client.tools()
+  const { text } = await generateText({
+    model: 'your-model',
+    tools,
+    prompt: [
+      'Read the WorkPaper summary with read_workpaper_summary for Summary!A1:B5.',
+      'Then set Inputs!B3 to 0.4 with set_workpaper_input_cell.',
+      'Return editedCell plus the before and after expectedArr values.',
+    ].join('\n'),
+  })
+
+  console.log(text)
+} finally {
+  await client.close()
+}
+```
+
+The important calls are still the MCP `read_workpaper_summary` read and the
+`set_workpaper_input_cell` write. The server command is `bilig-workpaper-mcp`;
+`npm exec --package @bilig/headless -- bilig-workpaper-mcp` just resolves the
+published package for a clean local recipe.
+
+Verify this docs recipe from the repo root with:
+
+```sh
+pnpm docs:discovery:check
+```
+
 ## Agent Writeback Verification
 
 Run the agent verification demo when you want a small artifact for the claim


### PR DESCRIPTION
## Summary

Add a compact Vercel AI SDK MCP client recipe for the WorkPaper stdio server in the MCP docs and headless example README.

## Proof

List the commands, tests, benchmarks, screenshots, or generated artifacts that
prove the change.

- [x] Focused checks run: `pnpm docs:discovery:check`
- [ ] `pnpm lint` (not run; docs-only change, narrower docs discovery gate used)
- [ ] `pnpm run ci` or a narrower justified gate (not run; docs-only change, `pnpm docs:discovery:check` plus diff check used)
- [x] `git diff --check -- examples/headless-workpaper/README.md docs/mcp-workpaper-tool-server.md`

## Risk

Low. Documentation-only change that adds an MCP client recipe and does not alter runtime code, formula semantics, persistence, benchmarks, browser behavior, sync, or agent-runtime implementation.

## Notes

Fixes #240.

New visitors should use `docs/mcp-workpaper-tool-server.md` or the `examples/headless-workpaper/README.md` MCP stdio section after merge.
