### PR TITLE
docs(mcp): add registry readiness checklist

### DIFF
--- a/docs/mcp-workpaper-tool-server.md
+++ b/docs/mcp-workpaper-tool-server.md
@@ -50,6 +50,21 @@ The package carries `mcpName: io.github.proompteng/bilig-workpaper` and a
 matching `server.json`, which is the metadata shape expected by MCP registries
 for npm-hosted stdio servers.
 
+Before submitting the server to an MCP registry, verify this repo-specific
+readiness checklist:
+
+- `packages/headless/server.json` exists and describes the packaged stdio
+  server.
+- `packages/headless/package.json` exposes `bilig-workpaper-mcp` in `bin`.
+- `packages/headless/package.json` includes
+  `mcpName: io.github.proompteng/bilig-workpaper`.
+- `pnpm publish:runtime:check` passes against the runtime packages.
+- `pnpm workpaper:smoke:external` passes against packed local runtime packages.
+
+Passing the checklist means the repository metadata and smoke checks are ready
+for registry submission; it does not mean the package has already been
+published.
+
 The script implements two JSON-RPC methods shaped around the MCP tool model:
 
 - `tools/list` returns `read_workpaper_summary` and

--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -422,6 +422,21 @@ Its package metadata includes `mcpName: io.github.proompteng/bilig-workpaper`
 and `server.json`, so the server can be published to MCP registries after the
 runtime package version is released.
 
+Before submitting the server to an MCP registry, verify this repo-specific
+readiness checklist:
+
+- `packages/headless/server.json` exists and describes the packaged stdio
+  server.
+- `packages/headless/package.json` exposes `bilig-workpaper-mcp` in `bin`.
+- `packages/headless/package.json` includes
+  `mcpName: io.github.proompteng/bilig-workpaper`.
+- `pnpm publish:runtime:check` passes against the runtime packages.
+- `pnpm workpaper:smoke:external` passes against packed local runtime packages.
+
+Passing the checklist means the package metadata and smoke checks are ready for
+registry submission; it does not mean this package version has already been
+published.
+
 For a framework-neutral recipe that wraps WorkPaper operations as agent-callable
 tools, see
 [`docs/agent-workpaper-tool-calling-recipe.md`](https://github.com/proompteng/bilig/blob/main/docs/agent-workpaper-tool-calling-recipe.md).


### PR DESCRIPTION
## Summary

Add a repo-specific MCP registry readiness checklist to the WorkPaper MCP docs and `@bilig/headless` README.

## Proof

- `pnpm install --frozen-lockfile` (passed; pnpm warned about missing generated bin before package build)
- `pnpm workspace-resolution:generate && pnpm --filter @bilig/protocol build && pnpm --filter @bilig/workbook-domain build && pnpm --filter @bilig/wasm-kernel build && pnpm --filter @bilig/formula build && pnpm --filter @bilig/core build && pnpm --filter @bilig/excel-import build && pnpm --filter @bilig/headless build` (passed)
- `pnpm publish:runtime:check` (initially failed before build because dist artifacts were missing; passed after the runtime package build)
- `pnpm workpaper:smoke:external` (passed)
- `git push` pre-push hook: `pnpm lint` (passed)

- [x] Focused checks run
- [x] `pnpm lint`
- [x] `pnpm run ci` or a narrower justified gate

## Risk

Docs-only change. No runtime, formula semantics, persistence, benchmark, browser, sync, or agent-runtime behavior changed.

## Notes

Fixes #239.

New visitors should use `docs/mcp-workpaper-tool-server.md` or the MCP section in `packages/headless/README.md` before submitting the packaged stdio server to an MCP registry.
