### PR TITLE
docs(try): add optional Docker smoke test for clean Node 24 runs

### DIFF
--- a/docs/try-bilig-headless-in-node.md
+++ b/docs/try-bilig-headless-in-node.md
@@ -109,6 +109,38 @@ Expected output:
 The exact byte count can change between package versions. The important part is
 that `verified` is `true` and `afterRestore` matches `after`.
 
+## Try it in Docker (optional)
+
+> **Note:** pnpm is the primary recommended path. This section is for
+> evaluators who prefer not to change their local Node version.
+
+After completing the **Run it** step above you will have an `eval.ts` file
+inside `bilig-headless-eval/`. Mount that directory into an official Node 24
+container and run the same script:
+
+```sh
+docker run --rm \
+  -v "$(pwd)":/eval \
+  -w /eval \
+  node:24-slim \
+  bash -c "npm install --silent && npx tsx eval.ts"
+```
+
+Expected output (same as above — `verified` must be `true`):
+
+```json
+{
+  "before": 24000,
+  "after": 38400,
+  "afterRestore": 38400,
+  "bytes": 1000,
+  "verified": true
+}
+```
+
+No repo clone is needed. The container installs dependencies from npm and exits
+cleanly after printing the result.
+
 ## What this proves
 
 - multi-sheet workbook creation from plain arrays


### PR DESCRIPTION
Closes #266

## What changed
Added a short optional `## Try it in Docker (optional)` section to `docs/try-bilig-headless-in-node.md`.

## Why
Evaluators who don't want to change their local Node version can now run the existing smoke test inside a clean `node:24-slim` container with a single copy-paste command.

## Details
- Uses the official `node:24-slim` Docker image (Node 24)
- Mounts the local `bilig-headless-eval/` directory — no repo clone needed
- Section is explicitly marked optional; pnpm remains the primary path
- Expected output repeats `"verified": true` so readers don't have to scroll
- No other files modified

## Acceptance criteria
- ✅ Reader can run the smoke test in a clean container without cloning the repo
- ✅ Section stays short and does not bury the main npm commands
- ✅ Expected output highlights `verified: true`
