### PR TITLE
docs(examples): add Vercel Function WorkPaper route smoke

### DIFF
--- a/docs/serverless-workpaper-api-route.md
+++ b/docs/serverless-workpaper-api-route.md
@@ -18,7 +18,8 @@ with `npm run framework-adapters`.
 
 For a copyable Next.js App Router boundary, the same example ships a runnable
 `npm run next-route-handler` smoke that exports `GET()` and `POST()` around the
-shared WorkPaper handler.
+shared WorkPaper handler. For a plain Vercel Function boundary, use
+`npm run vercel-function` or the example-level `npm run test` proof.
 
 ## Setup
 
@@ -507,6 +508,25 @@ Use the modern web handler form for new Vercel Functions. The Node-style bridge
 exists only for older projects where Vercel has already handed you a
 request/response pair. In either form, keep durable workbook storage behind the
 `createWorkPaperRequestHandler(storage)` boundary before deploying.
+
+The repository example includes this as a runnable TypeScript smoke so the
+adapter is more than documentation:
+
+```sh
+cd examples/serverless-workpaper-api
+npm install
+npm run vercel-function
+```
+
+The smoke calls the exported `GET()`, `POST()`, and `default.fetch()` entrypoints,
+then prints `verified: true` only when the response proves that formula output
+recalculated to `totalRevenue: 48600` and the serialized WorkPaper document
+still contains formulas. The example-level acceptance command is:
+
+```sh
+cd examples/serverless-workpaper-api
+npm run test
+```
 
 ## Cloudflare Worker Adapter
 
@@ -1656,6 +1676,6 @@ curl -s -X POST http://localhost:8787/api/workpaper/revenue \
 For a documentation patch in this repository:
 
 ```sh
+cd examples/serverless-workpaper-api && npm run test
 pnpm docs:discovery:check
-pnpm run ci
 ```

--- a/examples/serverless-workpaper-api/README.md
+++ b/examples/serverless-workpaper-api/README.md
@@ -12,7 +12,7 @@ Run it outside the monorepo with the published package:
 
 ```sh
 npm install
-npm run smoke
+npm run test
 npm run next-route-handler
 npm run next-server-action
 npm run next-server-action-formdata
@@ -76,6 +76,61 @@ The lower-level `createWorkPaperRequestHandler(storage)` helper accepts
 shape when the serialized WorkPaper document should live in a database, object
 store, KV namespace, Durable Object, or another durable service instead of
 module memory.
+
+## Vercel Function Smoke
+
+Run the Vercel Function-shaped smoke when you want a copyable `/api` function
+boundary for a deployed Node runtime:
+
+```sh
+npm run vercel-function
+```
+
+The script exports web-standard `GET(request)` and `POST(request)` handlers,
+plus a `default.fetch(request)` entrypoint for single-file Vercel Functions.
+Each entrypoint delegates to the shared WorkPaper request handler, writes a
+revenue update, reads the saved workbook again, and prints `verified: true`
+only after the formula totals recalculate and the persisted document still
+contains formulas.
+
+Expected output:
+
+```json
+{
+  "route": "Vercel Function",
+  "entrypoints": ["GET", "POST", "default.fetch"],
+  "before": {
+    "largestDeal": 24000,
+    "totalRevenue": 36900,
+    "westCustomers": 20
+  },
+  "edit": {
+    "records": 4,
+    "after": {
+      "largestDeal": 24000,
+      "totalRevenue": 48600,
+      "westCustomers": 20
+    },
+    "checks": {
+      "formulasPersisted": true,
+      "serializedBytes": 1195,
+      "totalRevenueChanged": true
+    }
+  },
+  "after": {
+    "largestDeal": 24000,
+    "totalRevenue": 48600,
+    "westCustomers": 20
+  },
+  "verified": true
+}
+```
+
+Run the focused proof used by this example with:
+
+```sh
+npm run test
+```
 
 ## Next.js App Router Smoke
 
@@ -362,7 +417,7 @@ Expected output shape:
   `'use server'` action functions like `readRevenueSummaryAction()` and
   `updateRevenueRecordsAction()`.
 - In a Vercel Function, export small web-standard `GET()` and `POST()` handlers
-  from files under `/api`.
+  from files under `/api`; the runnable `vercel-function.ts` smoke shows the deployed Node function shape.
 - In a Cloudflare Worker, call it from `fetch(request)`.
 - In Cloudflare Pages Functions, call it from small `onRequestGet()` and
   `onRequestPost()` files under `/functions`.

--- a/examples/serverless-workpaper-api/package.json
+++ b/examples/serverless-workpaper-api/package.json
@@ -11,7 +11,9 @@
     "persistence-adapters": "tsx persistence-adapters.ts",
     "smoke": "tsx smoke.ts",
     "start": "tsx route.ts",
-    "typecheck": "tsc --noEmit"
+    "test": "npm run smoke && npm run vercel-function",
+    "typecheck": "tsc --noEmit",
+    "vercel-function": "tsx vercel-function.ts"
   },
   "dependencies": {
     "@bilig/headless": "latest"

--- a/examples/serverless-workpaper-api/vercel-function.ts
+++ b/examples/serverless-workpaper-api/vercel-function.ts
@@ -1,0 +1,196 @@
+import { pathToFileURL } from 'node:url'
+
+import { createInMemoryWorkbookStorage, createWorkPaperRequestHandler } from './route.ts'
+
+const handleWorkPaperRequest = createWorkPaperRequestHandler(createInMemoryWorkbookStorage())
+
+/**
+ * Vercel Functions can expose web-standard method handlers from files under
+ * `/api`. Keep each exported function thin and let the shared WorkPaper route
+ * own formula evaluation, persistence, and JSON readback checks.
+ */
+export function GET(request: Request): Promise<Response> {
+  return handleWorkPaperRequest(request)
+}
+
+export function POST(request: Request): Promise<Response> {
+  return handleWorkPaperRequest(request)
+}
+
+/**
+ * Some Vercel runtimes also accept a single Fetch-style default export. Use it
+ * when one function file should own both WorkPaper route methods.
+ */
+const vercelFetchEntrypoint = {
+  fetch(request: Request): Promise<Response> {
+    return handleWorkPaperRequest(request)
+  },
+}
+
+export default vercelFetchEntrypoint
+
+export async function createVercelFunctionDemoOutput() {
+  const before = await requestJson(
+    GET(new Request('https://workpaper.example.vercel.app/api/workpaper/summary')),
+    parseSummaryResponse,
+    'vercel summary before',
+  )
+  const edit = await requestJson(
+    POST(
+      new Request('https://workpaper.example.vercel.app/api/workpaper/revenue', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          records: [
+            { region: 'West', customers: 20, arpa: 1200 },
+            { region: 'East', customers: 30, arpa: 250 },
+            { region: 'Central', customers: 18, arpa: 300 },
+            { region: 'North', customers: 65, arpa: 180 },
+          ],
+        }),
+      }),
+    ),
+    parseEditResponse,
+    'vercel revenue edit',
+  )
+  const after = await requestJson(
+    vercelFetchEntrypoint.fetch(new Request('https://workpaper.example.vercel.app/api/workpaper/summary')),
+    parseSummaryResponse,
+    'vercel summary after',
+  )
+
+  const output = {
+    route: 'Vercel Function',
+    entrypoints: ['GET', 'POST', 'default.fetch'],
+    before: before.summary,
+    edit: {
+      records: edit.records,
+      after: edit.after,
+      checks: edit.checks,
+    },
+    after: after.summary,
+    verified: true,
+  }
+
+  assertOutput(output)
+  return output
+}
+
+type Summary = {
+  largestDeal: number
+  totalRevenue: number
+  westCustomers: number
+}
+
+type SummaryResponse = {
+  summary: Summary
+}
+
+type EditResponse = {
+  after: Summary
+  checks: {
+    formulasPersisted: boolean
+    serializedBytes: number
+    totalRevenueChanged: boolean
+  }
+  records: number
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  console.log(JSON.stringify(await createVercelFunctionDemoOutput(), null, 2))
+}
+
+async function requestJson<T>(responsePromise: Promise<Response>, parse: (value: unknown) => T, label: string): Promise<T> {
+  const response = await responsePromise
+  const body: unknown = await response.json()
+  if (!response.ok) {
+    throw new Error(`${label} failed: ${response.status} ${JSON.stringify(body)}`)
+  }
+  return parse(body)
+}
+
+function parseSummaryResponse(value: unknown): SummaryResponse {
+  const record = readJsonRecord(value, 'summary response')
+  return {
+    summary: readSummary(record.summary, 'summary response summary'),
+  }
+}
+
+function parseEditResponse(value: unknown): EditResponse {
+  const record = readJsonRecord(value, 'edit response')
+  const checks = readJsonRecord(record.checks, 'edit response checks')
+  return {
+    after: readSummary(record.after, 'edit response after'),
+    checks: {
+      formulasPersisted: readBoolean(checks.formulasPersisted, 'edit response formulasPersisted'),
+      serializedBytes: readNumber(checks.serializedBytes, 'edit response serializedBytes'),
+      totalRevenueChanged: readBoolean(checks.totalRevenueChanged, 'edit response totalRevenueChanged'),
+    },
+    records: readNumber(record.records, 'edit response records'),
+  }
+}
+
+function readSummary(value: unknown, label: string): Summary {
+  const record = readJsonRecord(value, label)
+  return {
+    largestDeal: readNumber(record.largestDeal, `${label} largestDeal`),
+    totalRevenue: readNumber(record.totalRevenue, `${label} totalRevenue`),
+    westCustomers: readNumber(record.westCustomers, `${label} westCustomers`),
+  }
+}
+
+function readJsonRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isJsonRecord(value)) {
+    throw new Error(`${label} must be an object`)
+  }
+  return value
+}
+
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function readNumber(value: unknown, label: string): number {
+  if (typeof value !== 'number') {
+    throw new Error(`${label} must be a number`)
+  }
+  return value
+}
+
+function readBoolean(value: unknown, label: string): boolean {
+  if (typeof value !== 'boolean') {
+    throw new Error(`${label} must be a boolean`)
+  }
+  return value
+}
+
+function assertOutput(actual: Awaited<ReturnType<typeof createVercelFunctionDemoOutput>>): void {
+  const expectedBefore = {
+    largestDeal: 24000,
+    totalRevenue: 36900,
+    westCustomers: 20,
+  }
+  const expectedAfter = {
+    largestDeal: 24000,
+    totalRevenue: 48600,
+    westCustomers: 20,
+  }
+
+  if (
+    actual.route !== 'Vercel Function' ||
+    !actual.entrypoints.includes('GET') ||
+    !actual.entrypoints.includes('POST') ||
+    !actual.entrypoints.includes('default.fetch') ||
+    JSON.stringify(actual.before) !== JSON.stringify(expectedBefore) ||
+    JSON.stringify(actual.edit.after) !== JSON.stringify(expectedAfter) ||
+    JSON.stringify(actual.after) !== JSON.stringify(expectedAfter) ||
+    actual.edit.records !== 4 ||
+    !actual.edit.checks.totalRevenueChanged ||
+    !actual.edit.checks.formulasPersisted ||
+    actual.edit.checks.serializedBytes <= 0
+  ) {
+    throw new Error(`unexpected Vercel Function output: ${JSON.stringify(actual)}`)
+  }
+}


### PR DESCRIPTION
## Summary

Adds a runnable serverless WorkPaper API example for plain Vercel Function-style handlers. The new `vercel-function.ts` smoke exports `GET`, `POST`, and `default.fetch` entrypoints around the shared `@bilig/headless` route and verifies formula readback.

Fixes #346

## Proof

- [x] Focused checks run
  - `cd examples/serverless-workpaper-api && npm run test`
  - `cd examples/serverless-workpaper-api && npm run typecheck`
  - `pnpm docs:discovery:check`
- [ ] `pnpm lint`
- [ ] `pnpm run ci` or a narrower justified gate

## Risk

Low docs/example risk. The WorkPaper route logic is reused; the new adapter is a thin deployed-function shape plus smoke assertions.

## Notes

New visitors should start with `examples/serverless-workpaper-api/README.md` or `docs/serverless-workpaper-api-route.md` after merge.
