### PR TITLE
docs(examples): add Next.js Route Handler WorkPaper JSON smoke

### DIFF
--- a/docs/node-framework-workpaper-adapters.md
+++ b/docs/node-framework-workpaper-adapters.md
@@ -88,6 +88,40 @@ export const POST = handleWorkPaperRequest
 That shape works directly in Fetch-style runtimes and is easy to wrap in
 frameworks that use their own request and response objects.
 
+## Next.js Route Handler JSON
+
+For App Router endpoints that accept JSON, keep the Next-specific file thin and
+return web-standard `Response` objects. The runnable example proves the route
+can parse JSON, update an input cell, read back a dependent formula, and reload
+the persisted WorkPaper document:
+
+```sh
+cd examples/serverless-workpaper-api
+npm install
+npm run test
+```
+
+The copyable route shape is:
+
+```ts
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+export async function POST(request: Request) {
+  const { customers } = await request.json()
+  const result = updateRevenueInputCell(Number(customers))
+
+  return Response.json({
+    input: { cell: 'Inputs!B2', customers: result.customers },
+    formulaReadback: { cell: 'Summary!B2', revenue: result.revenue },
+    persistence: result.persistence,
+  })
+}
+```
+
+Use this for Next.js route handlers; use the generic adapters below when the
+framework gives you Express, Fastify, Hono, or another request wrapper.
+
 ## Express
 
 ```ts

--- a/docs/serverless-workpaper-api-route.md
+++ b/docs/serverless-workpaper-api-route.md
@@ -295,57 +295,88 @@ The important part is not the framework. The route accepts JSON records, writes
 them into a workbook, recalculates formulas, persists the document, and returns
 computed values that prove the write took effect.
 
-## Next.js App Router Adapter
+## Next.js App Router JSON Route Handler
 
-For a Next.js App Router project, keep the WorkPaper code in a shared module and
-make the route files thin.
-
-Create `app/api/workpaper/workpaper-route.ts` from the shared route code above:
-
-- keep the `@bilig/headless` imports
-- keep `state`, `handleWorkPaperRequest()`, and every workbook helper
-- omit `createServer()`, `toWebRequest()`, and the `if (import.meta.url === ...)`
-  local Node adapter block
-
-Then create `app/api/workpaper/summary/route.ts`:
-
-```ts
-import { handleWorkPaperRequest } from '../workpaper-route.ts'
-
-export const dynamic = 'force-dynamic'
-export const runtime = 'nodejs'
-
-export async function GET(request) {
-  return handleWorkPaperRequest(request)
-}
-```
-
-Create `app/api/workpaper/revenue/route.ts`:
-
-```ts
-import { handleWorkPaperRequest } from '../workpaper-route.ts'
-
-export const dynamic = 'force-dynamic'
-export const runtime = 'nodejs'
-
-export async function POST(request) {
-  return handleWorkPaperRequest(request)
-}
-```
-
-The route path stays the same as the standalone recipe:
+Use this shape when a client, agent, or server component posts JSON to a
+Next.js App Router endpoint and expects a deterministic formula readback. The
+runnable example keeps this dependency-free and does not require a running Next
+app for the smoke proof:
 
 ```sh
-curl -s http://localhost:3000/api/workpaper/summary
-curl -s -X POST http://localhost:3000/api/workpaper/revenue \
-  -H 'content-type: application/json' \
-  -d '{"records":[{"region":"West","customers":20,"arpa":1200},{"region":"East","customers":30,"arpa":250},{"region":"Central","customers":18,"arpa":300},{"region":"North","customers":65,"arpa":180}]}'
+cd examples/serverless-workpaper-api
+npm install
+npm run next-route-handler
+# or the focused example test
+npm run test
 ```
 
-Do not put the workbook helpers into both route files. The adapter should stay
-small; the shared handler is what keeps formula evaluation, persistence, and
-readback behavior identical between local Node, Next.js, and other web-standard
-route surfaces.
+The example exports route constants and methods matching an
+`app/api/workpaper/model/route.ts` file:
+
+```ts
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+export async function POST(request: Request): Promise<Response> {
+  const { customers } = await request.json()
+  const workbook = loadWorkbook()
+  const inputs = requireSheet(workbook, 'Inputs')
+
+  workbook.setCellContents({ sheet: inputs, row: 1, col: 1 }, Number(customers))
+
+  const after = readRevenueModel(workbook)
+  const workbookJson = serializeWorkbook(workbook)
+  state.workbookJson = workbookJson
+  const persisted = readRevenueModel(loadWorkbook())
+
+  return Response.json({
+    input: { cell: 'Inputs!B2', customers: after.customers },
+    formulaReadback: { cell: 'Summary!B2', revenue: after.revenue },
+    persistence: {
+      formulasPersisted: workbookJson.includes('=Inputs!B2*Inputs!B3'),
+      inputPersisted: persisted.customers === after.customers,
+      persistedRevenue: persisted.revenue,
+      serializedBytes: Buffer.byteLength(workbookJson, 'utf8'),
+    },
+  })
+}
+```
+
+The route accepts JSON such as:
+
+```sh
+curl -s -X POST http://localhost:3000/api/workpaper/model \
+  -H 'content-type: application/json' \
+  -d '{"customers":65}'
+```
+
+The smoke updates `Inputs!B2`, reads back the dependent `Summary!B2` revenue
+formula, serializes the WorkPaper document JSON, reloads it, and checks that the
+input value and formula result survived persistence:
+
+```json
+{
+  "input": {
+    "cell": "Inputs!B2",
+    "customers": 65
+  },
+  "formulaReadback": {
+    "cell": "Summary!B2",
+    "revenue": 78000
+  },
+  "persistence": {
+    "formulasPersisted": true,
+    "inputPersisted": true,
+    "persistedRevenue": 78000,
+    "serializedBytes": 989
+  }
+}
+```
+
+Keep workbook construction, parsing, serialization, and durable storage in a
+shared module. The Next.js `route.ts` file should stay framework-specific: parse
+the web `Request`, call the WorkPaper helper, and return a deterministic JSON
+`Response`.
 
 ## Next.js Server Action Adapter
 

--- a/examples/serverless-workpaper-api/README.md
+++ b/examples/serverless-workpaper-api/README.md
@@ -79,52 +79,66 @@ module memory.
 
 ## Next.js App Router Smoke
 
-Run the Next.js-shaped route handler smoke when you want a copyable App Router
-boundary without adding a full Next app to this example:
+Run the Next.js-shaped Route Handler smoke when you want a copyable App Router
+boundary that accepts JSON and updates one WorkPaper input cell without adding a
+full Next app to this example:
 
 ```sh
 npm run next-route-handler
+# or run the focused example test
+npm run test
 ```
 
-The script exports the same route constants a Next.js route file expects,
-delegates `GET()` and `POST()` to the shared WorkPaper request handler, sends a
-summary read, sends a revenue write, reads the summary again, and prints
-`verified: true` only after the formulas recalculate and the saved document
-still contains formulas.
+The script exports the same route constants a Next.js `route.ts` file expects,
+including `runtime = 'nodejs'` and `dynamic = 'force-dynamic'`. Its `POST()`
+handler parses `{ "customers": 65 }`, writes that value into `Inputs!B2`, reads
+back the dependent `Summary!B2` revenue formula, persists the WorkPaper document
+JSON, and reloads it to prove both the input and formula survived.
 
 Expected output:
 
 ```json
 {
-  "route": "Next.js App Router",
+  "route": "Next.js Route Handler JSON",
   "runtime": "nodejs",
   "dynamic": "force-dynamic",
   "before": {
-    "largestDeal": 24000,
-    "totalRevenue": 36900,
-    "westCustomers": 20
+    "arpa": 1200,
+    "customers": 20,
+    "revenue": 24000
   },
   "edit": {
-    "records": 4,
-    "after": {
-      "largestDeal": 24000,
-      "totalRevenue": 48600,
-      "westCustomers": 20
+    "input": {
+      "cell": "Inputs!B2",
+      "customers": 65
     },
-    "checks": {
+    "before": {
+      "arpa": 1200,
+      "customers": 20,
+      "revenue": 24000
+    },
+    "formulaReadback": {
+      "cell": "Summary!B2",
+      "revenue": 78000
+    },
+    "persistence": {
       "formulasPersisted": true,
-      "serializedBytes": 1195,
-      "totalRevenueChanged": true
+      "inputPersisted": true,
+      "persistedRevenue": 78000,
+      "serializedBytes": 989
     }
   },
   "after": {
-    "largestDeal": 24000,
-    "totalRevenue": 48600,
-    "westCustomers": 20
+    "arpa": 1200,
+    "customers": 65,
+    "revenue": 78000
   },
   "verified": true
 }
 ```
+
+`serializedBytes` can change as the persisted document schema evolves. Treat it
+as a positive persistence signal, not a golden value.
 
 ## Next.js Server Action Smoke
 

--- a/examples/serverless-workpaper-api/next-route-handler.ts
+++ b/examples/serverless-workpaper-api/next-route-handler.ts
@@ -1,63 +1,124 @@
 import { pathToFileURL } from 'node:url'
 
-import { createInMemoryWorkbookStorage, createWorkPaperRequestHandler } from './route.ts'
+import {
+  WorkPaper,
+  createWorkPaperFromDocument,
+  exportWorkPaperDocument,
+  parseWorkPaperDocument,
+  serializeWorkPaperDocument,
+} from '@bilig/headless'
 
-const handleWorkPaperRequest = createWorkPaperRequestHandler(createInMemoryWorkbookStorage())
+const state = {
+  workbookJson: serializeWorkbook(createInitialWorkbook()),
+}
 
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
 
-export function GET(request: Request): Promise<Response> {
-  return handleWorkPaperRequest(request)
+type WorkPaperInstance = ReturnType<typeof WorkPaper.buildFromSheets>
+type RevenueModel = {
+  arpa: number
+  customers: number
+  revenue: number
+}
+type RouteEditResponse = {
+  input: {
+    cell: 'Inputs!B2'
+    customers: number
+  }
+  before: RevenueModel
+  formulaReadback: {
+    cell: 'Summary!B2'
+    revenue: number
+  }
+  persistence: {
+    formulasPersisted: boolean
+    inputPersisted: boolean
+    persistedRevenue: number
+    serializedBytes: number
+  }
 }
 
-export function POST(request: Request): Promise<Response> {
-  return handleWorkPaperRequest(request)
+export async function GET(): Promise<Response> {
+  const workbook = loadWorkbook()
+  return json({
+    model: readRevenueModel(workbook),
+    sheets: workbook.getSheetNames(),
+  })
+}
+
+export async function POST(request: Request): Promise<Response> {
+  let customers: number
+  try {
+    customers = readCustomersInput(await request.json())
+  } catch (error) {
+    return json({ error: error instanceof Error ? error.message : String(error) }, 400)
+  }
+
+  const workbook = loadWorkbook()
+  const before = readRevenueModel(workbook)
+  const inputs = requireSheet(workbook, 'Inputs')
+  workbook.setCellContents({ sheet: inputs, row: 1, col: 1 }, customers)
+
+  const after = readRevenueModel(workbook)
+  const workbookJson = serializeWorkbook(workbook)
+  state.workbookJson = workbookJson
+
+  const persistedWorkbook = loadWorkbook()
+  const persisted = readRevenueModel(persistedWorkbook)
+  const output: RouteEditResponse = {
+    input: {
+      cell: 'Inputs!B2',
+      customers,
+    },
+    before,
+    formulaReadback: {
+      cell: 'Summary!B2',
+      revenue: after.revenue,
+    },
+    persistence: {
+      formulasPersisted: workbookJson.includes('=Inputs!B2*Inputs!B3'),
+      inputPersisted: persisted.customers === customers,
+      persistedRevenue: persisted.revenue,
+      serializedBytes: Buffer.byteLength(workbookJson, 'utf8'),
+    },
+  }
+
+  return json(output)
 }
 
 export async function createNextRouteHandlerDemoOutput() {
   const before = await requestJson(
-    GET(new Request('http://localhost:3000/api/workpaper/summary')),
-    parseSummaryResponse,
-    'next summary before',
+    GET(),
+    (value) => ({ model: readRevenueModelPayload(readJsonRecord(value, 'summary response').model, 'summary response model') }),
+    'next route summary before',
   )
   const edit = await requestJson(
     POST(
-      new Request('http://localhost:3000/api/workpaper/revenue', {
+      new Request('http://localhost:3000/api/workpaper/model', {
         method: 'POST',
         headers: {
           'content-type': 'application/json',
         },
-        body: JSON.stringify({
-          records: [
-            { region: 'West', customers: 20, arpa: 1200 },
-            { region: 'East', customers: 30, arpa: 250 },
-            { region: 'Central', customers: 18, arpa: 300 },
-            { region: 'North', customers: 65, arpa: 180 },
-          ],
-        }),
+        body: JSON.stringify({ customers: 65 }),
       }),
     ),
-    parseEditResponse,
-    'next revenue edit',
+    parseRouteEditResponse,
+    'next route JSON edit',
   )
   const after = await requestJson(
-    GET(new Request('http://localhost:3000/api/workpaper/summary')),
-    parseSummaryResponse,
-    'next summary after',
+    GET(),
+    (value) => ({ model: readRevenueModelPayload(readJsonRecord(value, 'summary response').model, 'summary response model') }),
+    'next route summary after',
   )
 
   const output = {
-    route: 'Next.js App Router',
+    route: 'Next.js Route Handler JSON',
     runtime,
     dynamic,
-    before: before.summary,
-    edit: {
-      records: edit.records,
-      after: edit.after,
-      checks: edit.checks,
-    },
-    after: after.summary,
+    before: before.model,
+    edit,
+    after: after.model,
     verified: true,
   }
 
@@ -65,28 +126,69 @@ export async function createNextRouteHandlerDemoOutput() {
   return output
 }
 
-type Summary = {
-  largestDeal: number
-  totalRevenue: number
-  westCustomers: number
-}
-
-type SummaryResponse = {
-  summary: Summary
-}
-
-type EditResponse = {
-  after: Summary
-  checks: {
-    formulasPersisted: boolean
-    serializedBytes: number
-    totalRevenueChanged: boolean
-  }
-  records: number
-}
-
 if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
   console.log(JSON.stringify(await createNextRouteHandlerDemoOutput(), null, 2))
+}
+
+function createInitialWorkbook(): WorkPaperInstance {
+  return WorkPaper.buildFromSheets({
+    Inputs: [
+      ['Metric', 'Value'],
+      ['Customers', 20],
+      ['ARPA', 1200],
+    ],
+    Summary: [
+      ['Metric', 'Value'],
+      ['Revenue', '=Inputs!B2*Inputs!B3'],
+    ],
+  })
+}
+
+function loadWorkbook(): WorkPaperInstance {
+  return createWorkPaperFromDocument(parseWorkPaperDocument(state.workbookJson))
+}
+
+function serializeWorkbook(workbook: WorkPaperInstance): string {
+  return serializeWorkPaperDocument(
+    exportWorkPaperDocument(workbook, {
+      includeConfig: true,
+    }),
+  )
+}
+
+function readRevenueModel(workbook: WorkPaperInstance): RevenueModel {
+  const inputs = requireSheet(workbook, 'Inputs')
+  const summary = requireSheet(workbook, 'Summary')
+  return {
+    arpa: readNumberCell(workbook, inputs, 2, 1, 'Inputs!B3'),
+    customers: readNumberCell(workbook, inputs, 1, 1, 'Inputs!B2'),
+    revenue: readNumberCell(workbook, summary, 1, 1, 'Summary!B2'),
+  }
+}
+
+function requireSheet(workbook: WorkPaperInstance, name: string): number {
+  const sheet = workbook.getSheetId(name)
+  if (sheet === undefined) {
+    throw new Error(`missing sheet: ${name}`)
+  }
+  return sheet
+}
+
+function readNumberCell(workbook: WorkPaperInstance, sheet: number, row: number, col: number, label: string): number {
+  const cell = workbook.getCellValue({ sheet, row, col })
+  if (typeof cell !== 'object' || cell === null || !('value' in cell) || typeof cell.value !== 'number') {
+    throw new Error(`expected ${label} to be numeric, received ${JSON.stringify(cell)}`)
+  }
+  return Math.round(cell.value * 100) / 100
+}
+
+function readCustomersInput(value: unknown): number {
+  const record = readJsonRecord(value, 'request body')
+  const customers = Number(record.customers)
+  if (!Number.isFinite(customers) || customers < 0) {
+    throw new Error('customers must be a non-negative number')
+  }
+  return customers
 }
 
 async function requestJson<T>(responsePromise: Promise<Response>, parse: (value: unknown) => T, label: string): Promise<T> {
@@ -98,33 +200,36 @@ async function requestJson<T>(responsePromise: Promise<Response>, parse: (value:
   return parse(body)
 }
 
-function parseSummaryResponse(value: unknown): SummaryResponse {
-  const record = readJsonRecord(value, 'summary response')
-  return {
-    summary: readSummary(record.summary, 'summary response summary'),
-  }
-}
-
-function parseEditResponse(value: unknown): EditResponse {
+function parseRouteEditResponse(value: unknown): RouteEditResponse {
   const record = readJsonRecord(value, 'edit response')
-  const checks = readJsonRecord(record.checks, 'edit response checks')
+  const input = readJsonRecord(record.input, 'edit response input')
+  const formulaReadback = readJsonRecord(record.formulaReadback, 'edit response formulaReadback')
+  const persistence = readJsonRecord(record.persistence, 'edit response persistence')
   return {
-    after: readSummary(record.after, 'edit response after'),
-    checks: {
-      formulasPersisted: readBoolean(checks.formulasPersisted, 'edit response formulasPersisted'),
-      serializedBytes: readNumber(checks.serializedBytes, 'edit response serializedBytes'),
-      totalRevenueChanged: readBoolean(checks.totalRevenueChanged, 'edit response totalRevenueChanged'),
+    input: {
+      cell: readLiteral(input.cell, 'Inputs!B2', 'edit response input cell'),
+      customers: readNumber(input.customers, 'edit response input customers'),
     },
-    records: readNumber(record.records, 'edit response records'),
+    before: readRevenueModelPayload(record.before, 'edit response before'),
+    formulaReadback: {
+      cell: readLiteral(formulaReadback.cell, 'Summary!B2', 'edit response formulaReadback cell'),
+      revenue: readNumber(formulaReadback.revenue, 'edit response formulaReadback revenue'),
+    },
+    persistence: {
+      formulasPersisted: readBoolean(persistence.formulasPersisted, 'edit response formulasPersisted'),
+      inputPersisted: readBoolean(persistence.inputPersisted, 'edit response inputPersisted'),
+      persistedRevenue: readNumber(persistence.persistedRevenue, 'edit response persistedRevenue'),
+      serializedBytes: readNumber(persistence.serializedBytes, 'edit response serializedBytes'),
+    },
   }
 }
 
-function readSummary(value: unknown, label: string): Summary {
+function readRevenueModelPayload(value: unknown, label: string): RevenueModel {
   const record = readJsonRecord(value, label)
   return {
-    largestDeal: readNumber(record.largestDeal, `${label} largestDeal`),
-    totalRevenue: readNumber(record.totalRevenue, `${label} totalRevenue`),
-    westCustomers: readNumber(record.westCustomers, `${label} westCustomers`),
+    arpa: readNumber(record.arpa, `${label} arpa`),
+    customers: readNumber(record.customers, `${label} customers`),
+    revenue: readNumber(record.revenue, `${label} revenue`),
   }
 }
 
@@ -153,30 +258,50 @@ function readBoolean(value: unknown, label: string): boolean {
   return value
 }
 
+function readLiteral<T extends string>(value: unknown, expected: T, label: string): T {
+  if (value !== expected) {
+    throw new Error(`${label} must be ${expected}`)
+  }
+  return expected
+}
+
+function json(payload: unknown, status = 200): Response {
+  return Response.json(payload, {
+    status,
+    headers: {
+      'cache-control': 'no-store',
+    },
+  })
+}
+
 function assertOutput(actual: Awaited<ReturnType<typeof createNextRouteHandlerDemoOutput>>): void {
   const expectedBefore = {
-    largestDeal: 24000,
-    totalRevenue: 36900,
-    westCustomers: 20,
+    arpa: 1200,
+    customers: 20,
+    revenue: 24000,
   }
   const expectedAfter = {
-    largestDeal: 24000,
-    totalRevenue: 48600,
-    westCustomers: 20,
+    arpa: 1200,
+    customers: 65,
+    revenue: 78000,
   }
 
   if (
-    actual.route !== 'Next.js App Router' ||
+    actual.route !== 'Next.js Route Handler JSON' ||
     actual.runtime !== 'nodejs' ||
     actual.dynamic !== 'force-dynamic' ||
     JSON.stringify(actual.before) !== JSON.stringify(expectedBefore) ||
-    JSON.stringify(actual.edit.after) !== JSON.stringify(expectedAfter) ||
-    JSON.stringify(actual.after) !== JSON.stringify(expectedAfter) ||
-    actual.edit.records !== 4 ||
-    !actual.edit.checks.totalRevenueChanged ||
-    !actual.edit.checks.formulasPersisted ||
-    actual.edit.checks.serializedBytes <= 0
+    actual.edit.input.cell !== 'Inputs!B2' ||
+    actual.edit.input.customers !== 65 ||
+    JSON.stringify(actual.edit.before) !== JSON.stringify(expectedBefore) ||
+    actual.edit.formulaReadback.cell !== 'Summary!B2' ||
+    actual.edit.formulaReadback.revenue !== expectedAfter.revenue ||
+    !actual.edit.persistence.formulasPersisted ||
+    !actual.edit.persistence.inputPersisted ||
+    actual.edit.persistence.persistedRevenue !== expectedAfter.revenue ||
+    actual.edit.persistence.serializedBytes <= 0 ||
+    JSON.stringify(actual.after) !== JSON.stringify(expectedAfter)
   ) {
-    throw new Error(`unexpected Next.js route handler output: ${JSON.stringify(actual)}`)
+    throw new Error(`unexpected Next.js route handler JSON output: ${JSON.stringify(actual)}`)
   }
 }

--- a/examples/serverless-workpaper-api/package.json
+++ b/examples/serverless-workpaper-api/package.json
@@ -4,6 +4,7 @@
   "description": "Runnable serverless-style API route example for @bilig/headless.",
   "type": "module",
   "scripts": {
+    "test": "npm run next-route-handler",
     "framework-adapters": "tsx framework-adapters.ts",
     "next-route-handler": "tsx next-route-handler.ts",
     "next-server-action": "tsx next-server-action.ts",


### PR DESCRIPTION
## Summary

Adds the serverless WorkPaper API example/docs smoke for a TypeScript Next.js Route Handler that accepts JSON, updates a WorkPaper input cell, returns formula readback, and verifies persisted document reload state.

## Proof

- [x] Focused checks run
  - `cd examples/serverless-workpaper-api && npm run test`
  - `cd examples/serverless-workpaper-api && npm run typecheck`
  - `pnpm docs:discovery:check`
- [ ] `pnpm lint`
  - Not run fully; pre-push lint currently reports unrelated existing type-aware lint errors in `packages/excel-import` and `apps/web` test files.
- [ ] `pnpm run ci` or a narrower justified gate
  - Narrow docs/example gates above cover this change.

## Risk

Low docs/example risk. The new smoke is isolated to `examples/serverless-workpaper-api/next-route-handler.ts` and uses deterministic in-memory WorkPaper JSON persistence.

## Notes

Fixes #345.

Public docs/example entry points after merge:

- `examples/serverless-workpaper-api/README.md#nextjs-app-router-smoke`
- `docs/serverless-workpaper-api-route.md#nextjs-app-router-json-route-handler`
