### PR TITLE
test(core): add semicolon-quoted CSV fixture with decimal-comma numbers

### DIFF
--- a/packages/core/src/__tests__/csv.test.ts
+++ b/packages/core/src/__tests__/csv.test.ts
@@ -81,6 +81,12 @@ describe('csv helpers', () => {
       ['Account', 'Amount', 'Tax'],
       ['4000', '125,50', '20,08'],
     ])
+    expect(
+      parseCsv('Name;Description;Amount\nFoo;"contains;semicolon";125,50'),
+    ).toEqual([
+      ['Name', 'Description', 'Amount'],
+      ['Foo', 'contains;semicolon', '125,50'],
+    ])
   })
 
   it('parses CSV cell inputs into formulas, booleans, numbers, raw strings, or empties', () => {


### PR DESCRIPTION
## Summary

Adds a test fixture for semicolon-delimited CSV rows containing quoted semicolons and decimal-comma numbers. Extends the existing `auto-detects semicolon-delimited CSV rows` test.

Fixes #364

## Root Cause

The semicolon-delimited CSV auto-detection only had one test fixture (simple numeric rows). No test covered the edge case of quoted fields containing semicolons alongside decimal-comma number fields.

## Fix

Added an additional `expect()` block to the existing semicolon detection test with a fixture row:
- Header: `Name;Description;Amount`
- Data: `Foo;"contains;semicolon";125,50`

## Changes

| File | Changes |
|------|---------|
| `packages/core/src/__tests__/csv.test.ts` | +6 lines |

## Testing

- [x] `pnpm --filter @bilig/core test -- --run csv.test.ts` passes
- [x] Quoted semicolon field parsed correctly (quotes stripped, semicolon preserved)
- [x] Decimal-comma number preserved as string in raw CSV parse