### PR TITLE
test(examples): add malformed CSV smoke

### DIFF
--- a/examples/headless-workpaper/README.md
+++ b/examples/headless-workpaper/README.md
@@ -39,35 +39,35 @@ packages through `pnpm workpaper:smoke:external`.
 
 ## Command Index
 
-| Use case                 | Command                            | What it proves                                                                                                    |
-| ------------------------ | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| Quick revenue workbook   | `npm start`                        | formulas, named expressions, persistence                                                                          |
-| Agent tool call loop     | `npm run agent:tool-call`          | read, edit, verify, serialize, restore                                                                            |
-| OpenAI Responses wrapper | `npm run agent:openai-responses`   | `function_call` dispatch, `function_call_output`, verified WorkPaper readback                                     |
+| Use case                 | Command                              | What it proves                                                                                                    |
+| ------------------------ | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| Quick revenue workbook   | `npm start`                          | formulas, named expressions, persistence                                                                          |
+| Agent tool call loop     | `npm run agent:tool-call`            | read, edit, verify, serialize, restore                                                                            |
+| OpenAI Responses wrapper | `npm run agent:openai-responses`     | `function_call` dispatch, `function_call_output`, verified WorkPaper readback                                     |
 | AI SDK generateText      | `npm run agent:ai-sdk-generate-text` | real `generateText()` and `tool()` calls with verified WorkPaper readback                                         |
-| AI SDK streamText        | `npm run agent:ai-sdk-stream-text` | real `streamText()` and streamed tool calls with verified WorkPaper readback                                      |
-| Agent framework adapters | `npm run agent:framework-adapters` | TypeScript wrappers for AI SDK, LangChain, Mastra, LlamaIndex.TS, LangGraph.js, CopilotKit, and Cloudflare Agents |
-| MCP tool server shape    | `npm run agent:mcp-tools`          | `tools/list`, `tools/call`, verified edits                                                                        |
-| MCP stdio server         | `npm run agent:mcp-stdio`          | newline-delimited JSON-RPC over stdin/stdout                                                                      |
-| npm package eval         | `npm run npm-eval`                 | the same `.ts` file used by the npm-only smoke test                                                               |
-| Agent writeback check    | `npm run agent:verify`             | exact input edits and formula preservation                                                                        |
-| Budget variance alerts   | `npm run budget-variance`          | budget, actuals, variance, alert formulas                                                                         |
-| Fulfillment capacity     | `npm run fulfillment-capacity`     | orders, labor hours, capacity gap                                                                                 |
-| Quote approval           | `npm run quote-approval`           | quote total, discount, approval threshold                                                                         |
-| Subscription MRR         | `npm run subscription-mrr`         | churn, expansion, ending MRR forecast                                                                             |
-| Revenue scenarios        | `npm run scenarios`                | multi-sheet formulas and planning edits                                                                           |
-| Persistence round trip   | `npm run persistence`              | save, restore, edit, and export                                                                                   |
-| Named expression update  | `npm run named-expression`         | workbook-scoped names and dependent formulas                                                                      |
-| CSV-shaped input         | `npm run csv-shaped`               | CSV-shaped data plus formula summary                                                                              |
-| Invoice totals           | `npm run invoice-totals`           | line items, subtotal, tax, total                                                                                  |
-| JSON records input       | `npm run json-records`             | API records to formula-backed workbook                                                                            |
-| JSON file input          | `npm run json-file`                | disk JSON records to verified summary                                                                             |
-| Formula diagnostics      | `npm run formula-diagnostics`      | display errors and structured diagnostics                                                                         |
-| Markdown report output   | `npm run markdown-report`          | calculated plain-text report generation                                                                           |
-| Snapshot diff            | `npm run snapshot-diff`            | persisted before/after input and outputs                                                                          |
-| Range readback           | `npm run range-readback`           | computed values and serialized formulas                                                                           |
-| Sheet inspection         | `npm run sheet-inspection`         | restored sheet names, IDs, and dimensions                                                                         |
-| HTTP JSON summary        | `npm run http-json-summary`        | no-framework Node HTTP service boundary                                                                           |
+| AI SDK streamText        | `npm run agent:ai-sdk-stream-text`   | real `streamText()` and streamed tool calls with verified WorkPaper readback                                      |
+| Agent framework adapters | `npm run agent:framework-adapters`   | TypeScript wrappers for AI SDK, LangChain, Mastra, LlamaIndex.TS, LangGraph.js, CopilotKit, and Cloudflare Agents |
+| MCP tool server shape    | `npm run agent:mcp-tools`            | `tools/list`, `tools/call`, verified edits                                                                        |
+| MCP stdio server         | `npm run agent:mcp-stdio`            | newline-delimited JSON-RPC over stdin/stdout                                                                      |
+| npm package eval         | `npm run npm-eval`                   | the same `.ts` file used by the npm-only smoke test                                                               |
+| Agent writeback check    | `npm run agent:verify`               | exact input edits and formula preservation                                                                        |
+| Budget variance alerts   | `npm run budget-variance`            | budget, actuals, variance, alert formulas                                                                         |
+| Fulfillment capacity     | `npm run fulfillment-capacity`       | orders, labor hours, capacity gap                                                                                 |
+| Quote approval           | `npm run quote-approval`             | quote total, discount, approval threshold                                                                         |
+| Subscription MRR         | `npm run subscription-mrr`           | churn, expansion, ending MRR forecast                                                                             |
+| Revenue scenarios        | `npm run scenarios`                  | multi-sheet formulas and planning edits                                                                           |
+| Persistence round trip   | `npm run persistence`                | save, restore, edit, and export                                                                                   |
+| Named expression update  | `npm run named-expression`           | workbook-scoped names and dependent formulas                                                                      |
+| CSV-shaped input         | `npm run csv-shaped`                 | CSV-shaped data plus formula summary                                                                              |
+| Invoice totals           | `npm run invoice-totals`             | line items, subtotal, tax, total                                                                                  |
+| JSON records input       | `npm run json-records`               | API records to formula-backed workbook                                                                            |
+| JSON file input          | `npm run json-file`                  | disk JSON records to verified summary                                                                             |
+| Formula diagnostics      | `npm run formula-diagnostics`        | display errors and structured diagnostics                                                                         |
+| Markdown report output   | `npm run markdown-report`            | calculated plain-text report generation                                                                           |
+| Snapshot diff            | `npm run snapshot-diff`              | persisted before/after input and outputs                                                                          |
+| Range readback           | `npm run range-readback`             | computed values and serialized formulas                                                                           |
+| Sheet inspection         | `npm run sheet-inspection`           | restored sheet names, IDs, and dimensions                                                                         |
+| HTTP JSON summary        | `npm run http-json-summary`          | no-framework Node HTTP service boundary                                                                           |
 
 For durable service storage, see the docs recipe for
 [plain node-postgres (`pg`) WorkPaper JSON persistence](../../docs/node-service-workpaper-recipe.md#plain-node-postgres-pg-json-persistence).
@@ -895,6 +895,13 @@ than hand-coded arithmetic:
 
 ```sh
 npm run csv-shaped
+```
+
+Run the malformed CSV smoke to confirm bad input fails before a workbook is
+created:
+
+```sh
+npm run csv-shaped:malformed
 ```
 
 Expected output:

--- a/examples/headless-workpaper/README.md
+++ b/examples/headless-workpaper/README.md
@@ -897,13 +897,6 @@ than hand-coded arithmetic:
 npm run csv-shaped
 ```
 
-Run the malformed CSV smoke to confirm bad input fails before a workbook is
-created:
-
-```sh
-npm run csv-shaped:malformed
-```
-
 Expected output:
 
 ```json
@@ -915,6 +908,22 @@ Expected output:
     "largestDeal": 24000
   },
   "serializedFirstDataRow": ["West", 20, 1200, "=B2*C2"],
+  "verified": true
+}
+```
+
+Run the malformed CSV smoke to confirm bad input fails before a workbook is
+created:
+
+```sh
+npm run csv-shaped:malformed
+```
+
+Expected output:
+
+```json
+{
+  "malformedCsvError": "expected 3 CSV fields on data row 3, received 2",
   "verified": true
 }
 ```

--- a/examples/headless-workpaper/csv-shaped-input.ts
+++ b/examples/headless-workpaper/csv-shaped-input.ts
@@ -14,44 +14,84 @@ East,30,250
 Central,18,300
 `.trim()
 
-const sourceRows = parseRevenueCsv(csvInput)
-const revenueRows = sourceRows.map((row, index) => {
-  const spreadsheetRow = index + 2
-  return [
-    row.region,
-    readInputNumber(row.customers, `customers row ${spreadsheetRow}`),
-    readInputNumber(row.arpa, `arpa row ${spreadsheetRow}`),
-    `=B${spreadsheetRow}*C${spreadsheetRow}`,
-  ]
-})
+const malformedCsvInput = `
+region,customers,arpa
+West,20,1200
+East,30
+Central,18,300
+`.trim()
 
-const workbook = WorkPaper.buildFromSheets({
-  Revenue: [['Region', 'Customers', 'ARPA', 'Revenue'], ...revenueRows],
-  Summary: [
-    ['Metric', 'Value'],
-    ['Total revenue', '=SUM(Revenue!D2:D4)'],
-    ['West customers', '=SUMIF(Revenue!A2:A4,"West",Revenue!B2:B4)'],
-    ['Largest deal', '=MAX(Revenue!D2:D4)'],
-  ],
-})
-
-const revenueSheet = requireSheet(workbook, 'Revenue')
-const summarySheet = requireSheet(workbook, 'Summary')
-const serializedRevenueSheet = workbook.getSheetSerialized(revenueSheet)
-
-const output = {
-  sourceRows: sourceRows.length,
-  computed: {
-    totalRevenue: readComputedNumber(workbook, summarySheet, 1, 1, 'total revenue'),
-    westCustomers: readComputedNumber(workbook, summarySheet, 2, 1, 'West customers'),
-    largestDeal: readComputedNumber(workbook, summarySheet, 3, 1, 'largest deal'),
-  },
-  serializedFirstDataRow: readSerializedRow(serializedRevenueSheet, 1, 'Revenue row 2'),
-  verified: true,
+if (process.argv.includes('--malformed-smoke')) {
+  runMalformedCsvSmoke()
+} else {
+  const output = buildRevenueSummary(csvInput)
+  assertSummary(output)
+  console.log(JSON.stringify(output, null, 2))
 }
 
-assertSummary(output)
-console.log(JSON.stringify(output, null, 2))
+function buildRevenueSummary(input: string) {
+  const sourceRows = parseRevenueCsv(input)
+  const revenueRows = sourceRows.map((row, index) => {
+    const spreadsheetRow = index + 2
+    return [
+      row.region,
+      readInputNumber(row.customers, `customers row ${spreadsheetRow}`),
+      readInputNumber(row.arpa, `arpa row ${spreadsheetRow}`),
+      `=B${spreadsheetRow}*C${spreadsheetRow}`,
+    ]
+  })
+
+  const workbook = WorkPaper.buildFromSheets({
+    Revenue: [['Region', 'Customers', 'ARPA', 'Revenue'], ...revenueRows],
+    Summary: [
+      ['Metric', 'Value'],
+      ['Total revenue', '=SUM(Revenue!D2:D4)'],
+      ['West customers', '=SUMIF(Revenue!A2:A4,"West",Revenue!B2:B4)'],
+      ['Largest deal', '=MAX(Revenue!D2:D4)'],
+    ],
+  })
+
+  const revenueSheet = requireSheet(workbook, 'Revenue')
+  const summarySheet = requireSheet(workbook, 'Summary')
+  const serializedRevenueSheet = workbook.getSheetSerialized(revenueSheet)
+
+  return {
+    sourceRows: sourceRows.length,
+    computed: {
+      totalRevenue: readComputedNumber(workbook, summarySheet, 1, 1, 'total revenue'),
+      westCustomers: readComputedNumber(workbook, summarySheet, 2, 1, 'West customers'),
+      largestDeal: readComputedNumber(workbook, summarySheet, 3, 1, 'largest deal'),
+    },
+    serializedFirstDataRow: readSerializedRow(serializedRevenueSheet, 1, 'Revenue row 2'),
+    verified: true,
+  }
+}
+
+function runMalformedCsvSmoke(): void {
+  try {
+    buildRevenueSummary(malformedCsvInput)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    const expectedMessage = 'expected 3 CSV fields on data row 3, received 2'
+    if (message !== expectedMessage) {
+      throw new Error(`Unexpected malformed CSV error: ${message}`, { cause: error })
+    }
+
+    console.log(
+      JSON.stringify(
+        {
+          malformedCsvError: message,
+          verified: true,
+        },
+        null,
+        2,
+      ),
+    )
+    return
+  }
+
+  throw new Error('Expected malformed CSV input to fail before building a WorkPaper')
+}
 
 function parseRevenueCsv(input: string): RevenueCsvRow[] {
   const lines = input
@@ -117,7 +157,7 @@ function readSerializedRow(sheet: unknown, rowIndex: number, label: string): unk
   return sheet[rowIndex]
 }
 
-function assertSummary(summary: typeof output): void {
+function assertSummary(summary: ReturnType<typeof buildRevenueSummary>): void {
   const expected = {
     sourceRows: 3,
     computed: {

--- a/examples/headless-workpaper/package.json
+++ b/examples/headless-workpaper/package.json
@@ -14,6 +14,7 @@
     "agent:verify": "tsx agent-writeback-verification.ts",
     "budget-variance": "tsx budget-variance-alerts.ts",
     "csv-shaped": "tsx csv-shaped-input.ts",
+    "csv-shaped:malformed": "tsx csv-shaped-input.ts --malformed-smoke",
     "formula-diagnostics": "tsx formula-diagnostics.ts",
     "fulfillment-capacity": "tsx fulfillment-capacity-plan.ts",
     "http-json-summary": "tsx http-json-summary.ts",


### PR DESCRIPTION
## Summary
- Refactor the csv-shaped input example so the normal WorkPaper summary path stays unchanged
- Add a malformed CSV smoke path that verifies a missing `arpa` field fails with a row-specific field-count error
- Document the new `npm run csv-shaped:malformed` command

Fixes #370

## Test Plan
- `pnpm --dir examples/headless-workpaper run csv-shaped`
- `pnpm --dir examples/headless-workpaper run csv-shaped:malformed`
- `pnpm --dir examples/headless-workpaper run typecheck`
- `pnpm docs:discovery:check`
- `pnpm exec oxfmt --check examples/headless-workpaper/csv-shaped-input.ts examples/headless-workpaper/package.json examples/headless-workpaper/README.md`

Note: local pre-push full lint currently fails on unrelated existing type-aware lint errors in packages/core, apps/web, and packages/excel-import tests under Node v23.11.0; targeted checks for this example pass.
