### PR TITLE
docs(examples): add Server Action validation smoke

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -172,6 +172,9 @@ npm run agent:verify
 - Next.js Server Action FormData WorkPaper smoke:
   npm run next-server-action-formdata
   https://github.com/proompteng/bilig/tree/main/examples/serverless-workpaper-api#nextjs-server-action-formdata-smoke
+- Next.js Server Action validation-error WorkPaper smoke:
+  npm run next-server-action-validation
+  https://github.com/proompteng/bilig/tree/main/examples/serverless-workpaper-api#nextjs-server-action-validation-smoke
 - Express, Fastify, Hono, Oak, Hapi, and AdonisJS WorkPaper adapters:
   https://proompteng.github.io/bilig/node-framework-workpaper-adapters.html
   https://github.com/proompteng/bilig/blob/main/docs/node-framework-workpaper-adapters.md

--- a/docs/serverless-workpaper-api-route.md
+++ b/docs/serverless-workpaper-api-route.md
@@ -447,6 +447,41 @@ The smoke output includes `action: "Next.js Server Action FormData"` and
 `verified: true` only after formula readback and saved-document formula
 persistence both pass.
 
+## Next.js Server Action Validation Adapter
+
+Use the validation-error smoke when a Server Action should reject malformed
+form input before it reaches the WorkPaper mutation route:
+
+```sh
+cd examples/serverless-workpaper-api
+npm install
+npm run next-server-action-validation
+```
+
+The example submits a FormData payload with `customers: "-1"` through the same
+parser as the FormData action, catches the validation error, then reads the
+summary again. `unchanged: true` proves the rejected action did not mutate the
+persisted workbook state.
+
+```json
+{
+  "action": "Next.js Server Action FormData validation",
+  "validationError": "record 1 customers must be a non-negative number",
+  "summaryBefore": {
+    "largestDeal": 24000,
+    "totalRevenue": 36900,
+    "westCustomers": 20
+  },
+  "summaryAfter": {
+    "largestDeal": 24000,
+    "totalRevenue": 36900,
+    "westCustomers": 20
+  },
+  "unchanged": true,
+  "verified": true
+}
+```
+
 ## Vercel Function Adapter
 
 Plain Vercel Functions can use the same web-standard `Request` and `Response`

--- a/examples/serverless-workpaper-api/README.md
+++ b/examples/serverless-workpaper-api/README.md
@@ -16,6 +16,7 @@ npm run test
 npm run next-route-handler
 npm run next-server-action
 npm run next-server-action-formdata
+npm run next-server-action-validation
 npm run framework-adapters
 npm run persistence-adapters
 ```
@@ -298,6 +299,50 @@ Expected output:
     "totalRevenue": 48600,
     "westCustomers": 20
   },
+  "verified": true
+}
+```
+
+## Next.js Server Action Validation Smoke
+
+Run the validation-error Server Action smoke when a form action should reject
+bad input before mutating WorkPaper state:
+
+```sh
+npm run next-server-action-validation
+```
+
+The script submits a FormData payload with a negative `customers` value through
+the same Server Action parser used by the FormData smoke. It catches the
+validation error, reads the summary again, and prints `unchanged: true` only
+when the workbook summary is identical before and after the rejected action.
+
+Expected output:
+
+```json
+{
+  "action": "Next.js Server Action FormData validation",
+  "rejectedInput": {
+    "fields": ["region", "customers", "arpa"],
+    "records": 1,
+    "shape": {
+      "region": ["West"],
+      "customers": ["-1"],
+      "arpa": ["1200"]
+    }
+  },
+  "validationError": "record 1 customers must be a non-negative number",
+  "summaryBefore": {
+    "largestDeal": 24000,
+    "totalRevenue": 36900,
+    "westCustomers": 20
+  },
+  "summaryAfter": {
+    "largestDeal": 24000,
+    "totalRevenue": 36900,
+    "westCustomers": 20
+  },
+  "unchanged": true,
   "verified": true
 }
 ```

--- a/examples/serverless-workpaper-api/next-server-action-validation.ts
+++ b/examples/serverless-workpaper-api/next-server-action-validation.ts
@@ -1,0 +1,105 @@
+import { pathToFileURL } from 'node:url'
+
+import { readRevenueSummaryAction, updateRevenueRecordsFromFormDataAction } from './next-server-action-formdata.ts'
+
+type Summary = {
+  largestDeal: number
+  totalRevenue: number
+  westCustomers: number
+}
+
+const formFields = ['region', 'customers', 'arpa'] as const
+
+export async function validateRevenueRecordsFromFormDataAction(formData: FormData) {
+  'use server'
+
+  const before = await readRevenueSummaryAction()
+  let validationError: string | undefined
+
+  try {
+    await updateRevenueRecordsFromFormDataAction(formData)
+  } catch (error) {
+    validationError = error instanceof Error ? error.message : String(error)
+  }
+
+  const after = await readRevenueSummaryAction()
+  const output = {
+    action: 'Next.js Server Action FormData validation',
+    rejectedInput: {
+      fields: formFields,
+      records: readFormRecordCount(formData),
+      shape: readFormShape(formData),
+    },
+    validationError,
+    summaryBefore: before.summary,
+    summaryAfter: after.summary,
+    unchanged: summariesMatch(before.summary, after.summary),
+    verified: true,
+  }
+
+  assertOutput(output)
+  return output
+}
+
+export async function createNextServerActionValidationDemoOutput() {
+  return validateRevenueRecordsFromFormDataAction(createInvalidRevenueFormData())
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  console.log(JSON.stringify(await createNextServerActionValidationDemoOutput(), null, 2))
+}
+
+function createInvalidRevenueFormData(): FormData {
+  const formData = new FormData()
+  formData.append('region', 'West')
+  formData.append('customers', '-1')
+  formData.append('arpa', '1200')
+  return formData
+}
+
+function readFormRecordCount(formData: FormData): number {
+  return Math.max(0, ...formFields.map((field) => formData.getAll(field).length))
+}
+
+function readFormShape(formData: FormData): Record<(typeof formFields)[number], string[]> {
+  return {
+    region: readStringEntries(formData, 'region'),
+    customers: readStringEntries(formData, 'customers'),
+    arpa: readStringEntries(formData, 'arpa'),
+  }
+}
+
+function readStringEntries(formData: FormData, name: (typeof formFields)[number]): string[] {
+  return formData.getAll(name).map((value) => (typeof value === 'string' ? value : '[file]'))
+}
+
+function summariesMatch(left: Summary, right: Summary): boolean {
+  return JSON.stringify(left) === JSON.stringify(right)
+}
+
+function assertOutput(actual: Awaited<ReturnType<typeof validateRevenueRecordsFromFormDataAction>>): void {
+  const expectedSummary = {
+    largestDeal: 24000,
+    totalRevenue: 36900,
+    westCustomers: 20,
+  }
+
+  if (
+    actual.action !== 'Next.js Server Action FormData validation' ||
+    JSON.stringify(actual.rejectedInput.fields) !== JSON.stringify(formFields) ||
+    actual.rejectedInput.records !== 1 ||
+    JSON.stringify(actual.rejectedInput.shape) !==
+      JSON.stringify({
+        region: ['West'],
+        customers: ['-1'],
+        arpa: ['1200'],
+      }) ||
+    actual.validationError !== 'record 1 customers must be a non-negative number' ||
+    JSON.stringify(actual.summaryBefore) !== JSON.stringify(expectedSummary) ||
+    JSON.stringify(actual.summaryAfter) !== JSON.stringify(expectedSummary) ||
+    !actual.unchanged ||
+    !actual.verified
+  ) {
+    throw new Error(`unexpected Next.js Server Action validation output: ${JSON.stringify(actual)}`)
+  }
+}

--- a/examples/serverless-workpaper-api/package.json
+++ b/examples/serverless-workpaper-api/package.json
@@ -9,6 +9,7 @@
     "next-route-handler": "tsx next-route-handler.ts",
     "next-server-action": "tsx next-server-action.ts",
     "next-server-action-formdata": "tsx next-server-action-formdata.ts",
+    "next-server-action-validation": "tsx next-server-action-validation.ts",
     "persistence-adapters": "tsx persistence-adapters.ts",
     "smoke": "tsx smoke.ts",
     "start": "tsx route.ts",

--- a/scripts/check-docs-discovery-serverless.ts
+++ b/scripts/check-docs-discovery-serverless.ts
@@ -22,6 +22,7 @@ export async function requireServerlessWorkPaperApiDiscovery({
   await requireFile(join(repoRoot, 'examples', 'serverless-workpaper-api', 'next-route-handler.ts'))
   await requireFile(join(repoRoot, 'examples', 'serverless-workpaper-api', 'next-server-action.ts'))
   await requireFile(join(repoRoot, 'examples', 'serverless-workpaper-api', 'next-server-action-formdata.ts'))
+  await requireFile(join(repoRoot, 'examples', 'serverless-workpaper-api', 'next-server-action-validation.ts'))
   await requireFile(join(repoRoot, 'examples', 'serverless-workpaper-api', 'persistence-adapters.ts'))
 
   const [
@@ -57,6 +58,12 @@ export async function requireServerlessWorkPaperApiDiscovery({
   requireIncludes(llms, 'Next.js Server Action FormData WorkPaper smoke', 'docs/llms.txt')
   requireIncludes(llms, 'npm run next-server-action-formdata', 'docs/llms.txt')
   requireIncludes(readme, 'npm run next-server-action-formdata', 'README.md')
+  requireIncludes(serverlessExampleReadme, 'npm run next-server-action-validation', 'examples/serverless-workpaper-api/README.md')
+  requireIncludes(serverlessExampleReadme, '## Next.js Server Action Validation Smoke', 'examples/serverless-workpaper-api/README.md')
+  requireIncludes(serverlessWorkPaperApiRouteDoc, 'npm run next-server-action-validation', 'docs/serverless-workpaper-api-route.md')
+  requireIncludes(serverlessWorkPaperApiRouteDoc, '## Next.js Server Action Validation Adapter', 'docs/serverless-workpaper-api-route.md')
+  requireIncludes(llms, 'Next.js Server Action validation-error WorkPaper smoke', 'docs/llms.txt')
+  requireIncludes(llms, 'npm run next-server-action-validation', 'docs/llms.txt')
 
   requireIncludes(serverlessExampleReadme, 'npm run framework-adapters', 'examples/serverless-workpaper-api/README.md')
   requireIncludes(serverlessExampleReadme, '## Framework Adapters', 'examples/serverless-workpaper-api/README.md')
@@ -110,6 +117,11 @@ export async function requireServerlessWorkPaperApiDiscovery({
   requireIncludes(
     serverlessExamplePackage,
     '"next-server-action-formdata": "tsx next-server-action-formdata.ts"',
+    'examples/serverless-workpaper-api/package.json',
+  )
+  requireIncludes(
+    serverlessExamplePackage,
+    '"next-server-action-validation": "tsx next-server-action-validation.ts"',
     'examples/serverless-workpaper-api/package.json',
   )
   requireIncludes(


### PR DESCRIPTION
## Summary
- add a Next.js Server Action FormData validation-error smoke
- prove rejected negative numeric input returns a useful validation error without mutating the WorkPaper summary
- document the new npm script in the example README, route recipe, llms.txt, and docs discovery guard

Fixes #342

## Test Plan
- pnpm --dir examples/serverless-workpaper-api run next-server-action-validation
- pnpm --dir examples/serverless-workpaper-api run typecheck
- pnpm docs:discovery:check
- pnpm exec oxfmt --check examples/serverless-workpaper-api/README.md examples/serverless-workpaper-api/next-server-action-validation.ts examples/serverless-workpaper-api/package.json docs/serverless-workpaper-api-route.md docs/llms.txt scripts/check-docs-discovery.ts