### PR TITLE
Improve cache vs oracle wording in XLSX verifier docs

### DIFF
--- a/docs/xlsx-corpus-verifier-walkthrough.md
+++ b/docs/xlsx-corpus-verifier-walkthrough.md
@@ -1,5 +1,6 @@
 ---
 title: Do not trust stale XLSX cached formula values
+Cached XLSX values should be treated as diagnostic information only and may become stale over time. A cache mismatch alone should not be considered a real formula correctness bug unless verified through fresh Excel recalculation.
 published: true
 description: A TypeScript harness for separating XLSX import success, cache diagnostics, timeouts, and real formula accuracy against fresh Microsoft Excel recalculation.
 tags: typescript, node, excel, xlsx, spreadsheet, testing

--- a/docs/xlsx-corpus-verifier-walkthrough.md
+++ b/docs/xlsx-corpus-verifier-walkthrough.md
@@ -18,6 +18,8 @@ that saved it. That cached result is convenient for previewing a workbook
 without recalculating it. It is not proof that the formula still returns that
 value.
 
+For example, a stale cached XLSX value may differ from a freshly recalculated Excel result even when the underlying formula is correct.
+
 That distinction matters when you are evaluating `@bilig/headless` for a Node.js
 service, an agent tool, or a workbook automation job. A stale cache can make a
 correct engine look wrong. It can also make a wrong engine look correct.

--- a/docs/xlsx-corpus-verifier-walkthrough.md
+++ b/docs/xlsx-corpus-verifier-walkthrough.md
@@ -1,6 +1,5 @@
 ---
 title: Do not trust stale XLSX cached formula values
-Cached XLSX values should be treated as diagnostic information only and may become stale over time. A cache mismatch alone should not be considered a real formula correctness bug unless verified through fresh Excel recalculation.
 published: true
 description: A TypeScript harness for separating XLSX import success, cache diagnostics, timeouts, and real formula accuracy against fresh Microsoft Excel recalculation.
 tags: typescript, node, excel, xlsx, spreadsheet, testing
@@ -10,6 +9,9 @@ image: /assets/github-social-preview.png
 ---
 
 # Do not trust stale XLSX cached formula values
+
+Cached XLSX values should be treated as diagnostic information only and may become stale over time. A cache mismatch alone should not be considered a real formula correctness bug unless verified through fresh Excel recalculation.
+
 
 An `.xlsx` file can contain formula text and a cached result from the last app
 that saved it. That cached result is convenient for previewing a workbook


### PR DESCRIPTION
Updated documentation to clarify stale cached XLSX values and fresh Excel recalculation behavior.