### PR TITLE
docs(agent): add CrewAI WorkPaper tool recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Pick the path closest to what you are building.
   [agent tool-calling recipe](docs/agent-workpaper-tool-calling-recipe.md),
   [OpenAI Responses tools](docs/openai-responses-workpaper-tool-call.md),
   [AI SDK and LangChain adapters](docs/vercel-ai-sdk-langchain-spreadsheet-tool.md),
+  [CrewAI adapter](docs/crewai-workpaper-spreadsheet-tool.md),
   [agent framework adapters](examples/headless-workpaper#agent-framework-adapters),
   [MCP server guide](docs/mcp-workpaper-tool-server.md),
   [MCP tool server shape](examples/headless-workpaper#mcp-tool-server-shape),

--- a/docs/agent-workpaper-tool-calling-recipe.md
+++ b/docs/agent-workpaper-tool-calling-recipe.md
@@ -30,7 +30,10 @@ For a runnable external example, use
 For a smaller writeback-only proof, run
 `npm run agent:verify`. For framework-shaped wrappers that do not pull Vercel
 AI SDK or LangChain into this repository, run
-`npm run agent:framework-adapters`.
+`npm run agent:framework-adapters`. For a CrewAI interop shape, use the
+[CrewAI WorkPaper spreadsheet tool](crewai-workpaper-spreadsheet-tool.md)
+recipe; it keeps the WorkPaper code in TypeScript and exposes a small JSON
+contract to the agent workflow.
 If you want the real AI SDK loop, run `npm run agent:ai-sdk-generate-text`.
 That script calls `generateText()` and `tool()` from `ai`, using `ai/test` as a
 deterministic provider so no API key is needed.

--- a/docs/crewai-workpaper-spreadsheet-tool.md
+++ b/docs/crewai-workpaper-spreadsheet-tool.md
@@ -1,0 +1,101 @@
+---
+title: CrewAI WorkPaper spreadsheet tool
+published: true
+description: Expose @bilig/headless WorkPaper calculations to CrewAI as a small JSON tool contract with formula readback.
+tags: crewai, spreadsheet, workpaper, agent tools, typescript
+canonical_url: https://proompteng.github.io/bilig/crewai-workpaper-spreadsheet-tool.html
+cover_image: https://raw.githubusercontent.com/proompteng/bilig/main/docs/assets/github-social-preview.png
+image: /assets/github-social-preview.png
+---
+
+# CrewAI WorkPaper Spreadsheet Tool
+
+CrewAI workflows can call a WorkPaper-backed TypeScript service when an agent
+needs spreadsheet math, formula readback, or workbook persistence. Keep the
+CrewAI side as the orchestration layer; keep workbook construction, validation,
+formula calculation, and serialization in `@bilig/headless`.
+
+This is an interop recipe, not an official CrewAI adapter. The useful boundary
+is a small JSON contract:
+
+- input payload: `sheetName`, `address`, and `value`
+- formula readback: before/after computed `Summary` values
+- error shape: `{ ok: false, error: string }`
+
+## Run the checked adapter
+
+```sh
+git clone https://github.com/proompteng/bilig.git
+cd bilig/examples/headless-workpaper
+npm install
+npm run agent:framework-adapters
+```
+
+The CrewAI lane returns plain JSON tool metadata plus a verified WorkPaper write
+result:
+
+```json
+{
+  "toolNames": ["read_workpaper_summary", "set_workpaper_input_cell"],
+  "contract": {
+    "inputPayload": "validated JSON args",
+    "formulaReadback": "before/after computed Summary values",
+    "errorShape": "{ ok: false, error: string }"
+  },
+  "writeResult": {
+    "editedCell": "Inputs!B3",
+    "checks": {
+      "formulasPersisted": true,
+      "restoredMatchesAfter": true,
+      "expectedArrChanged": true
+    }
+  }
+}
+```
+
+## TypeScript service shape
+
+Expose narrow WorkPaper functions from a Node service and let CrewAI call them
+over HTTP, a queue, or any other app-owned transport:
+
+```ts
+import { z } from 'zod'
+
+const setInputCellInputSchema = z.object({
+  sheetName: z.literal('Inputs'),
+  address: z.string().regex(/^[A-Z]+[1-9][0-9]*$/),
+  value: z.union([z.string(), z.number(), z.boolean(), z.null()]),
+})
+
+export function runCrewAiWorkPaperTool(payload: unknown) {
+  const args = setInputCellInputSchema.safeParse(payload)
+  if (!args.success) {
+    return {
+      ok: false,
+      error: args.error.issues.map((issue) => issue.message).join('; '),
+    }
+  }
+
+  const result = setWorkPaperInputCell(args.data)
+  return {
+    ok: true,
+    result,
+  }
+}
+```
+
+The WorkPaper function behind `setWorkPaperInputCell` should build or load the
+workbook, write one validated input, read dependent formulas before and after
+the edit, and return a plain JSON result. The agent should receive evidence,
+not just an "updated" string.
+
+## What to copy
+
+- Validate agent-generated JSON before writing to the workbook.
+- Return the edited cell, before/after formula values, and persistence checks.
+- Keep the tool contract small enough for a CrewAI task to reason about.
+- Do not require CrewAI for normal `bilig` usage; the same WorkPaper functions
+  also work from Node services, queues, tests, and other agent frameworks.
+
+Runnable source:
+[`examples/headless-workpaper/agent-framework-adapters.ts`](../examples/headless-workpaper/agent-framework-adapters.ts).

--- a/docs/index.html
+++ b/docs/index.html
@@ -607,6 +607,7 @@ function readNumber(cell: unknown): number {
                 <li><a href="./langgraph-workpaper-toolnode-spreadsheet.html">LangGraph.js ToolNode</a></li>
                 <li><a href="./copilotkit-workpaper-spreadsheet-action.html">CopilotKit action</a></li>
                 <li><a href="./cloudflare-agents-workpaper-spreadsheet-tool.html">Cloudflare Agents tool</a></li>
+                <li><a href="./crewai-workpaper-spreadsheet-tool.html">CrewAI spreadsheet tool</a></li>
                 <li><a href="./mcp-workpaper-tool-server.html">MCP spreadsheet tool server</a></li>
                 <li><a href="./mcp-spreadsheet-server-directory.html">MCP directory status</a></li>
                 <li><a href="./mcp-client-setup.html">MCP client setup</a></li>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -31,6 +31,7 @@ language: typescript
 - https://proompteng.github.io/bilig/langgraph-workpaper-toolnode-spreadsheet.html
 - https://proompteng.github.io/bilig/copilotkit-workpaper-spreadsheet-action.html
 - https://proompteng.github.io/bilig/cloudflare-agents-workpaper-spreadsheet-tool.html
+- https://proompteng.github.io/bilig/crewai-workpaper-spreadsheet-tool.html
 - https://proompteng.github.io/bilig/mcp-workpaper-tool-server.html
 - https://proompteng.github.io/bilig/mcp-client-setup.html
 - https://proompteng.github.io/bilig/claude-desktop-mcpb-workpaper.html
@@ -214,8 +215,9 @@ npm run agent:verify
   https://proompteng.github.io/bilig/langgraph-workpaper-toolnode-spreadsheet.html
   https://proompteng.github.io/bilig/copilotkit-workpaper-spreadsheet-action.html
   https://proompteng.github.io/bilig/cloudflare-agents-workpaper-spreadsheet-tool.html
+  https://proompteng.github.io/bilig/crewai-workpaper-spreadsheet-tool.html
 - runnable AI SDK, LangChain, Mastra, LlamaIndex.TS, LangGraph.js, CopilotKit,
-  and Cloudflare Agents adapter example:
+  Cloudflare Agents, and CrewAI adapter example:
   https://github.com/proompteng/bilig/blob/main/examples/headless-workpaper/agent-framework-adapters.ts
 - runnable AI SDK generateText WorkPaper tool smoke:
   https://github.com/proompteng/bilig/blob/main/examples/headless-workpaper/ai-sdk-generate-text-tool-smoke.ts

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -61,6 +61,12 @@
     <priority>0.78</priority>
   </url>
   <url>
+    <loc>https://proompteng.github.io/bilig/crewai-workpaper-spreadsheet-tool.html</loc>
+    <lastmod>2026-05-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.78</priority>
+  </url>
+  <url>
     <loc>https://proompteng.github.io/bilig/mcp-workpaper-tool-server.html</loc>
     <lastmod>2026-05-13</lastmod>
     <changefreq>monthly</changefreq>

--- a/examples/headless-workpaper/README.md
+++ b/examples/headless-workpaper/README.md
@@ -46,7 +46,7 @@ packages through `pnpm workpaper:smoke:external`.
 | OpenAI Responses wrapper | `npm run agent:openai-responses`   | `function_call` dispatch, `function_call_output`, verified WorkPaper readback                                     |
 | AI SDK generateText      | `npm run agent:ai-sdk-generate-text` | real `generateText()` and `tool()` calls with verified WorkPaper readback                                         |
 | AI SDK streamText        | `npm run agent:ai-sdk-stream-text` | real `streamText()` and streamed tool calls with verified WorkPaper readback                                      |
-| Agent framework adapters | `npm run agent:framework-adapters` | TypeScript wrappers for AI SDK, LangChain, Mastra, LlamaIndex.TS, LangGraph.js, CopilotKit, and Cloudflare Agents |
+| Agent framework adapters | `npm run agent:framework-adapters` | TypeScript wrappers for AI SDK, LangChain, Mastra, LlamaIndex.TS, LangGraph.js, CopilotKit, Cloudflare Agents, and CrewAI |
 | MCP tool server shape    | `npm run agent:mcp-tools`          | `tools/list`, `tools/call`, verified edits                                                                        |
 | MCP stdio server         | `npm run agent:mcp-stdio`          | newline-delimited JSON-RPC over stdin/stdout                                                                      |
 | npm package eval         | `npm run npm-eval`                 | the same `.ts` file used by the npm-only smoke test                                                               |
@@ -159,7 +159,7 @@ For agent frameworks, the
 [`WorkPaper tool-calling recipe`](../../docs/agent-workpaper-tool-calling-recipe.md)
 also links to wrappers that keep the same validation and computed readback
 contract across the OpenAI Responses API, AI SDK, LangChain, Mastra,
-LlamaIndex.TS, LangGraph.js, CopilotKit, and Cloudflare Agents.
+LlamaIndex.TS, LangGraph.js, CopilotKit, Cloudflare Agents, and CrewAI.
 
 ## OpenAI Responses Tool Wrapper
 
@@ -361,6 +361,14 @@ Expected output:
   },
   "cloudflareAgents": {
     "toolNames": ["readWorkPaperSummary", "setWorkPaperInputCell"]
+  },
+  "crewAi": {
+    "toolNames": ["read_workpaper_summary", "set_workpaper_input_cell"],
+    "contract": {
+      "inputPayload": "validated JSON args",
+      "formulaReadback": "before/after computed Summary values",
+      "errorShape": "{ ok: false, error: string }"
+    }
   }
 }
 ```
@@ -375,6 +383,7 @@ adapts it to:
 - LlamaIndex.TS `tool(fn, { parameters })` / `FunctionTool` shapes
 - CopilotKit `useCopilotAction({ parameters, handler })` actions
 - Cloudflare Agents `AIChatAgent` / `streamText({ tools })` style tools
+- CrewAI-style JSON tool contracts for a TypeScript service boundary
 
 The actual output also includes read results, formula contracts, restored
 summary, and serialized byte counts for every write path.

--- a/examples/headless-workpaper/agent-framework-adapters.ts
+++ b/examples/headless-workpaper/agent-framework-adapters.ts
@@ -114,6 +114,19 @@ type LangGraphToolCall =
       name: 'set_workpaper_input_cell'
       args: SetInputCellArgs
     }
+type CrewAiTool =
+  | {
+      name: 'read_workpaper_summary'
+      description: string
+      argsSchema: typeof readSummaryInputSchema
+      run(args?: ReadSummaryArgs): WorkPaperReadResult
+    }
+  | {
+      name: 'set_workpaper_input_cell'
+      description: string
+      argsSchema: typeof setInputCellInputSchema
+      run(args: SetInputCellArgs): WorkPaperWriteResult
+    }
 
 const readSummaryInputSchema = z.object({
   range: z.string().default('Summary!A1:B5'),
@@ -153,6 +166,7 @@ const llamaIndexWorkbook = buildWorkbook()
 const langGraphWorkbook = buildWorkbook()
 const copilotKitWorkbook = buildWorkbook()
 const cloudflareAgentsWorkbook = buildWorkbook()
+const crewAiWorkbook = buildWorkbook()
 const aiSdkTools = createAiSdkTools(createWorkPaperTools(aiSdkWorkbook))
 const openAiResponsesTools = createOpenAiResponsesTools(createWorkPaperTools(openAiResponsesWorkbook))
 const langChainTools = createLangChainTools(createWorkPaperTools(langChainWorkbook))
@@ -162,6 +176,7 @@ const llamaIndexTools = createLlamaIndexTools(createWorkPaperTools(llamaIndexWor
 const langGraphToolNode = createLangGraphToolNode(createWorkPaperTools(langGraphWorkbook))
 const copilotKitActions = createCopilotKitActions(createWorkPaperTools(copilotKitWorkbook))
 const cloudflareAgentTools = createCloudflareAgentTools(createWorkPaperTools(cloudflareAgentsWorkbook))
+const crewAiTools = createCrewAiTools(createWorkPaperTools(crewAiWorkbook))
 
 const output = {
   aiSdk: {
@@ -250,6 +265,21 @@ const output = {
       address: 'B3',
       value: 0.4,
     }),
+  },
+  crewAi: {
+    toolNames: crewAiTools.map((tool) => tool.name),
+    contract: {
+      inputPayload: 'validated JSON args',
+      formulaReadback: 'before/after computed Summary values',
+      errorShape: '{ ok: false, error: string }',
+    },
+    writeResult: requireWorkPaperWriteResult(
+      requireCrewAiTool(crewAiTools, 'set_workpaper_input_cell').run({
+        sheetName: 'Inputs',
+        address: 'B3',
+        value: 0.4,
+      }),
+    ),
   },
 }
 
@@ -592,6 +622,27 @@ function createCloudflareAgentTools(workPaperTools: WorkPaperToolSet) {
   }
 }
 
+function createCrewAiTools(workPaperTools: WorkPaperToolSet): CrewAiTool[] {
+  return [
+    {
+      name: 'read_workpaper_summary',
+      description: 'Read computed WorkPaper summary values for a CrewAI tool call.',
+      argsSchema: readSummaryInputSchema,
+      run(args: ReadSummaryArgs = {}) {
+        return workPaperTools.readWorkPaperSummary(readSummaryInputSchema.parse(args).range)
+      },
+    },
+    {
+      name: 'set_workpaper_input_cell',
+      description: 'Set one validated WorkPaper input cell and return formula readback.',
+      argsSchema: setInputCellInputSchema,
+      run(args: SetInputCellArgs) {
+        return workPaperTools.setWorkPaperInputCell(setInputCellInputSchema.parse(args))
+      },
+    },
+  ]
+}
+
 function createWorkPaperTools(workbook: WorkPaperInstance) {
   const summarySheet = requireSheet(workbook, 'Summary')
 
@@ -690,6 +741,16 @@ function requireCopilotKitAction(actions: CopilotKitAction[], name: CopilotKitAc
     throw new Error(`Missing CopilotKit action: ${name}`)
   }
   return action
+}
+
+function requireCrewAiTool(tools: CrewAiTool[], name: 'read_workpaper_summary'): Extract<CrewAiTool, { name: 'read_workpaper_summary' }>
+function requireCrewAiTool(tools: CrewAiTool[], name: 'set_workpaper_input_cell'): Extract<CrewAiTool, { name: 'set_workpaper_input_cell' }>
+function requireCrewAiTool(tools: CrewAiTool[], name: CrewAiTool['name']): CrewAiTool {
+  const tool = tools.find((candidate) => candidate.name === name)
+  if (tool === undefined) {
+    throw new Error(`Missing CrewAI tool: ${name}`)
+  }
+  return tool
 }
 
 function requireLangGraphToolMessage(messages: LangGraphToolMessage[], toolCallId: string): LangGraphToolMessage {
@@ -808,6 +869,7 @@ function assertOutput(actual: typeof output): void {
     ['langGraph', actual.langGraph.writeResult],
     ['copilotKit', actual.copilotKit.writeResult],
     ['cloudflareAgents', actual.cloudflareAgents.writeResult],
+    ['crewAi', actual.crewAi.writeResult],
   ]
 
   for (const [framework, result] of writeResults) {

--- a/scripts/check-docs-discovery-agent-pages.ts
+++ b/scripts/check-docs-discovery-agent-pages.ts
@@ -4,6 +4,7 @@ export const agentFrameworkLlmsRequiredLinks = [
   'https://proompteng.github.io/bilig/langgraph-workpaper-toolnode-spreadsheet.html',
   'https://proompteng.github.io/bilig/copilotkit-workpaper-spreadsheet-action.html',
   'https://proompteng.github.io/bilig/cloudflare-agents-workpaper-spreadsheet-tool.html',
+  'https://proompteng.github.io/bilig/crewai-workpaper-spreadsheet-tool.html',
 ] as const
 
 export const agentFrameworkDocRequirements = [
@@ -26,5 +27,9 @@ export const agentFrameworkDocRequirements = [
   {
     path: 'docs/cloudflare-agents-workpaper-spreadsheet-tool.md',
     includes: ['Cloudflare Agents WorkPaper spreadsheet tool', 'agentTool', 'npm run agent:framework-adapters'],
+  },
+  {
+    path: 'docs/crewai-workpaper-spreadsheet-tool.md',
+    includes: ['CrewAI WorkPaper spreadsheet tool', 'JSON contract', 'npm run agent:framework-adapters'],
   },
 ] as const

--- a/scripts/check-docs-discovery-site-sources.ts
+++ b/scripts/check-docs-discovery-site-sources.ts
@@ -9,6 +9,7 @@ export const docsSiteSources = [
   ['langgraph-workpaper-toolnode-spreadsheet.html', 'langgraph-workpaper-toolnode-spreadsheet.md'],
   ['copilotkit-workpaper-spreadsheet-action.html', 'copilotkit-workpaper-spreadsheet-action.md'],
   ['cloudflare-agents-workpaper-spreadsheet-tool.html', 'cloudflare-agents-workpaper-spreadsheet-tool.md'],
+  ['crewai-workpaper-spreadsheet-tool.html', 'crewai-workpaper-spreadsheet-tool.md'],
   ['mcp-workpaper-tool-server.html', 'mcp-workpaper-tool-server.md'],
   ['mcp-spreadsheet-server-directory.html', 'mcp-spreadsheet-server-directory.md'],
   ['mcp-client-setup.html', 'mcp-client-setup.md'],


### PR DESCRIPTION
## Summary

Adds a CrewAI WorkPaper tool recipe for the headless example workflow.

This belongs to the public docs and `examples/headless-workpaper` agent adapter workflow. The runnable adapter now includes a `crewAi` lane that exposes validated JSON tool args, writes one WorkPaper input, and returns before/after formula readback as plain JSON.

Closes #396

## Proof

- [x] Focused checks run
- [ ] `pnpm lint`
- [x] `pnpm run ci` or a narrower justified gate

Focused checks run:

```sh
corepack pnpm exec oxfmt --check scripts/check-docs-discovery-agent-pages.ts scripts/check-docs-discovery-site-sources.ts examples/headless-workpaper/agent-framework-adapters.ts
npm run typecheck
npm run agent:framework-adapters
```

Also ran `corepack pnpm docs:discovery:check`; it fails locally on Windows because `docs/index.html` is checked out with CRLF and the existing homepage check looks for an LF-only multiline quickstart snippet. The required quickstart text is present in `docs/index.html`.

`corepack pnpm lint` currently fails on pre-existing type-aware lint errors outside this change in `packages/excel-import`, `apps/web`, and `packages/core`; none are in the files touched here.

## Risk

Low. This adds docs plus a new example adapter lane. It does not add a CrewAI runtime dependency and does not claim an official CrewAI adapter.

## Notes

New public page: `docs/crewai-workpaper-spreadsheet-tool.md`.