### PR TITLE
docs(examples): add SQLite persistence adapter

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -260,7 +260,7 @@ npm run agent:verify
 - runnable service persistence adapters:
   npm run persistence-adapters
   https://github.com/proompteng/bilig/blob/main/examples/serverless-workpaper-api/persistence-adapters.ts
-  Postgres JSONB, Redis/KV, and object storage all restore through the same WorkPaper request handler
+  Postgres JSONB, SQLite, Redis/KV, and object storage all restore through the same WorkPaper request handler
 - revenue model walkthrough:
   https://proompteng.github.io/bilig/building-a-revenue-model-with-headless-workpaper.html
   https://github.com/proompteng/bilig/blob/main/docs/building-a-revenue-model-with-headless-workpaper.md

--- a/docs/persisting-formula-backed-workpaper-documents-in-node.md
+++ b/docs/persisting-formula-backed-workpaper-documents-in-node.md
@@ -131,6 +131,8 @@ The source is
 It runs the real `createWorkPaperRequestHandler(storage)` boundary through:
 
 - a Postgres JSONB adapter with a `query(sql, values)` client shape
+- a SQLite adapter that stores serialized WorkPaper JSON by workbook id with
+  parameterized SQL
 - a Redis or string-KV adapter with `get(key)` and `set(key, value)`
 - an object-storage adapter with text load and save functions
 
@@ -138,7 +140,8 @@ Each adapter starts empty, loads the initial WorkPaper document, accepts a
 revenue edit, saves the serialized workbook JSON, creates a fresh handler, and
 then reads the restored workbook back. The script only prints `verified: true`
 after the cold read returns the recalculated total and the saved document still
-contains formulas.
+contains formulas. The durable value is the WorkPaper document state JSON, not
+an XLSX file cache.
 
 ## Object Storage Adapter
 

--- a/examples/serverless-workpaper-api/README.md
+++ b/examples/serverless-workpaper-api/README.md
@@ -435,11 +435,12 @@ memory:
 npm run persistence-adapters
 ```
 
-The script exercises the same WorkPaper request handler through three typed
+The script exercises the same WorkPaper request handler through four typed
 storage adapters:
 
 - Postgres JSONB, using a `query(sql, values)` client shape compatible with
   `pg`-style clients.
+- SQLite, using parameterized SQL and a workbook id.
 - Redis or another string KV store, using `get(key)` and `set(key, value)`.
 - Object storage such as S3, R2, GCS, or Azure Blob, using small text load and
   save functions.
@@ -447,19 +448,28 @@ storage adapters:
 Each adapter starts from an empty store, handles a summary read, accepts the
 revenue write, creates a fresh handler, then reads the restored workbook from
 the saved document. `verified: true` means formulas survived persistence and
-the cold read returned the recalculated total.
+the cold read returned the recalculated total. These adapters persist the
+serialized WorkPaper document state, not an XLSX file cache.
 
 Expected output shape:
 
 ```json
 {
-  "adapters": ["postgres-jsonb", "redis", "object-storage"],
+  "adapters": ["postgres-jsonb", "sqlite", "redis", "object-storage"],
   "postgres": {
     "before": {
       "totalRevenue": 36900,
       "westCustomers": 20,
       "largestDeal": 24000
     },
+    "after": {
+      "totalRevenue": 48600,
+      "westCustomers": 20,
+      "largestDeal": 24000
+    },
+    "verified": true
+  },
+  "sqlite": {
     "after": {
       "totalRevenue": 48600,
       "westCustomers": 20,

--- a/examples/serverless-workpaper-api/persistence-adapters.ts
+++ b/examples/serverless-workpaper-api/persistence-adapters.ts
@@ -34,6 +34,10 @@ type PostgresStorageOptions = DurableStorageOptions & {
   documentId: string
 }
 
+type SQLiteStorageOptions = DurableStorageOptions & {
+  documentId: string
+}
+
 type KeyedStorageOptions = DurableStorageOptions & {
   key: string
 }
@@ -50,6 +54,15 @@ export type PostgresWorkbookRow = {
 
 export type PostgresJsonbClient = {
   query(sql: string, values: readonly unknown[]): Promise<PostgresQueryResult<PostgresWorkbookRow>>
+}
+
+export type SQLiteWorkbookRow = {
+  workbook_json: string
+}
+
+export type SQLiteClient = {
+  get(sql: string, values: readonly unknown[]): Promise<SQLiteWorkbookRow | undefined> | SQLiteWorkbookRow | undefined
+  run(sql: string, values: readonly unknown[]): Promise<void> | void
 }
 
 export type RedisTextClient = {
@@ -95,6 +108,38 @@ export function createPostgresJsonbWorkPaperStorage(db: PostgresJsonbClient, opt
   }
 }
 
+export function createSQLiteWorkPaperStorage(db: SQLiteClient, options: SQLiteStorageOptions): WorkPaperJsonStorage {
+  return {
+    async loadWorkbookJson() {
+      const row = await db.get(
+        `
+          select workbook_json
+          from workpaper_documents
+          where id = ?
+        `,
+        [options.documentId],
+      )
+
+      if (row === undefined) {
+        return readInitialWorkbookJson(options.createInitialWorkbookJson)
+      }
+      return validateWorkbookJson(row.workbook_json)
+    },
+    async saveWorkbookJson(workbookJson: string) {
+      await db.run(
+        `
+          insert into workpaper_documents (id, workbook_json, updated_at)
+          values (?, ?, current_timestamp)
+          on conflict(id) do update
+            set workbook_json = excluded.workbook_json,
+                updated_at = current_timestamp
+        `,
+        [options.documentId, validateWorkbookJson(workbookJson)],
+      )
+    },
+  }
+}
+
 export function createRedisWorkPaperStorage(redis: RedisTextClient, options: KeyedStorageOptions): WorkPaperJsonStorage {
   return {
     async loadWorkbookJson() {
@@ -133,11 +178,17 @@ export async function createPersistenceAdapterDemoOutput() {
   const objectKey = 'workpapers/revenue-plan.json'
 
   const postgres = createInMemoryPostgresJsonbClient()
+  const sqlite = createInMemorySQLiteClient()
   const redis = createInMemoryRedisTextClient()
   const objectStore = createInMemoryObjectTextStore()
 
   const postgresRun = await exerciseStorage('postgres-jsonb', () =>
     createPostgresJsonbWorkPaperStorage(postgres, {
+      documentId,
+    }),
+  )
+  const sqliteRun = await exerciseStorage('sqlite', () =>
+    createSQLiteWorkPaperStorage(sqlite, {
       documentId,
     }),
   )
@@ -153,14 +204,16 @@ export async function createPersistenceAdapterDemoOutput() {
   )
 
   const output = {
-    adapters: ['postgres-jsonb', 'redis', 'object-storage'],
+    adapters: ['postgres-jsonb', 'sqlite', 'redis', 'object-storage'],
     postgres: postgresRun,
+    sqlite: sqliteRun,
     redis: redisRun,
     objectStorage: objectStoreRun,
     persistedBytes: {
       objectStorage: readByteLength(objectStore.getSavedText(objectKey), 'object store saved document'),
       postgres: readByteLength(postgres.getSavedWorkbookJson(documentId), 'postgres saved document'),
       redis: readByteLength(redis.getSavedText(redisKey), 'redis saved document'),
+      sqlite: readByteLength(sqlite.getSavedWorkbookJson(documentId), 'sqlite saved document'),
     },
     verified: true,
   }
@@ -313,16 +366,18 @@ function readByteLength(value: string | undefined, label: string): number {
 
 function assertOutput(actual: PersistenceAdapterDemoOutput): void {
   if (
-    actual.adapters.join(',') !== 'postgres-jsonb,redis,object-storage' ||
+    actual.adapters.join(',') !== 'postgres-jsonb,sqlite,redis,object-storage' ||
     !actual.verified ||
     actual.persistedBytes.postgres <= 0 ||
     actual.persistedBytes.redis <= 0 ||
+    actual.persistedBytes.sqlite <= 0 ||
     actual.persistedBytes.objectStorage <= 0
   ) {
     throw new Error(`unexpected persistence adapter output: ${JSON.stringify(actual)}`)
   }
 
   assertStorageRun(actual.postgres, 'postgres-jsonb')
+  assertStorageRun(actual.sqlite, 'sqlite')
   assertStorageRun(actual.redis, 'redis')
   assertStorageRun(actual.objectStorage, 'object-storage')
 }
@@ -377,6 +432,37 @@ function createInMemoryPostgresJsonbClient(): InMemoryPostgresJsonbClient {
       validateWorkbookJson(workbookJson)
       rows.set(documentId, workbookJson)
       return { rows: [] }
+    },
+  }
+}
+
+type InMemorySQLiteClient = SQLiteClient & {
+  getSavedWorkbookJson(documentId: string): string | undefined
+}
+
+function createInMemorySQLiteClient(): InMemorySQLiteClient {
+  const rows = new Map<string, string>()
+
+  return {
+    getSavedWorkbookJson(documentId: string) {
+      return rows.get(documentId)
+    },
+    get(sql: string, values: readonly unknown[]): SQLiteWorkbookRow | undefined {
+      if (!sql.includes('?')) {
+        throw new Error('SQLite statements must use parameter placeholders')
+      }
+      const documentId = readString(values[0], 'document id')
+      const workbookJson = rows.get(documentId)
+      return workbookJson === undefined ? undefined : { workbook_json: workbookJson }
+    },
+    run(sql: string, values: readonly unknown[]) {
+      if (!sql.includes('?')) {
+        throw new Error('SQLite statements must use parameter placeholders')
+      }
+      const documentId = readString(values[0], 'document id')
+      const workbookJson = readString(values[1], 'workbook json')
+      validateWorkbookJson(workbookJson)
+      rows.set(documentId, workbookJson)
     },
   }
 }

--- a/scripts/check-docs-discovery-serverless.ts
+++ b/scripts/check-docs-discovery-serverless.ts
@@ -89,13 +89,33 @@ export async function requireServerlessWorkPaperApiDiscovery({
   requireIncludes(serverlessExampleReadme, '## Persistence Adapters', 'examples/serverless-workpaper-api/README.md')
   requireIncludes(serverlessExampleReadme, 'Postgres JSONB', 'examples/serverless-workpaper-api/README.md')
   requireIncludes(
+    serverlessExampleReadme,
+    'SQLite, using parameterized SQL and a workbook id.',
+    'examples/serverless-workpaper-api/README.md',
+  )
+  requireIncludes(serverlessExampleReadme, 'not an XLSX file cache', 'examples/serverless-workpaper-api/README.md')
+  requireIncludes(
+    serverlessExampleReadme,
+    '"adapters": ["postgres-jsonb", "sqlite", "redis", "object-storage"]',
+    'examples/serverless-workpaper-api/README.md',
+  )
+  requireIncludes(serverlessExampleReadme, '"sqlite": {', 'examples/serverless-workpaper-api/README.md')
+  requireIncludes(
+    await readFile(join(repoRoot, 'examples', 'serverless-workpaper-api', 'persistence-adapters.ts'), 'utf8'),
+    'createSQLiteWorkPaperStorage',
+    'examples/serverless-workpaper-api/persistence-adapters.ts',
+  )
+  requireIncludes(
     persistenceDoc,
     'examples/serverless-workpaper-api/persistence-adapters.ts',
     'docs/persisting-formula-backed-workpaper-documents-in-node.md',
   )
   requireIncludes(persistenceDoc, 'npm run persistence-adapters', 'docs/persisting-formula-backed-workpaper-documents-in-node.md')
   requireIncludes(persistenceDoc, 'Postgres JSONB', 'docs/persisting-formula-backed-workpaper-documents-in-node.md')
+  requireIncludes(persistenceDoc, 'SQLite adapter', 'docs/persisting-formula-backed-workpaper-documents-in-node.md')
+  requireIncludes(persistenceDoc, 'XLSX file cache', 'docs/persisting-formula-backed-workpaper-documents-in-node.md')
   requireIncludes(persistenceDoc, 'Redis or string-KV adapter', 'docs/persisting-formula-backed-workpaper-documents-in-node.md')
+  requireIncludes(llms, 'Postgres JSONB, SQLite, Redis/KV, and object storage', 'docs/llms.txt')
 
   requireIncludes(
     serverlessExamplePackage,


### PR DESCRIPTION
## Summary
- add a SQLite-shaped WorkPaper JSON storage adapter with parameterized SQL
- include SQLite in the persistence adapter smoke and persisted-byte checks
- document that the durable value is serialized WorkPaper document state, not an XLSX cache

Fixes #400

## Test Plan
- pnpm --dir examples/serverless-workpaper-api run persistence-adapters
- pnpm --dir examples/serverless-workpaper-api run typecheck
- pnpm docs:discovery:check
- pnpm exec oxfmt --check examples/serverless-workpaper-api/persistence-adapters.ts examples/serverless-workpaper-api/README.md docs/persisting-formula-backed-workpaper-documents-in-node.md docs/llms.txt scripts/check-docs-discovery-serverless.ts